### PR TITLE
fix: use IntGaugeVec for watcher and home fail metrics and key by correct contracts

### DIFF
--- a/agents/relayer/src/relayer.rs
+++ b/agents/relayer/src/relayer.rs
@@ -204,6 +204,7 @@ mod test {
             let metrics = Arc::new(
                 CoreMetrics::new(
                     "contract_sync_test",
+                    "home",
                     None,
                     Arc::new(prometheus::Registry::new()),
                 )

--- a/agents/watcher/src/watcher.rs
+++ b/agents/watcher/src/watcher.rs
@@ -308,18 +308,20 @@ impl Watcher {
     ) -> Self {
         let double_updates_observed = core
             .metrics
-            .new_int_gauge(
+            .new_int_gauge_vec(
                 "double_updates_observed",
                 "Number of times a double update has been observed (anything > 0 is major red flag!)",
+                &["home", "agent"],
             )
-            .expect("failed to register watcher metric");
+            .expect("failed to register watcher metric")
+            .with_label_values(&[core.home.name(), Self::AGENT_NAME]);
 
         let updates_inspected_for_double = core
             .metrics
             .new_int_gauge_vec(
                 "updates_inspected_for_double",
                 "Number of updates inspected for double update per channel",
-                &["contract", "agent"],
+                &["home", "checked", "agent"],
             )
             .expect("failed to register watcher metric");
 
@@ -366,8 +368,11 @@ impl Watcher {
                         from,
                         tx.clone(),
                         replica.clone(),
-                        updates_inspected_for_double
-                            .with_label_values(&[replica.name(), Self::AGENT_NAME]),
+                        updates_inspected_for_double.with_label_values(&[
+                            home.name(),
+                            replica.name(),
+                            Self::AGENT_NAME,
+                        ]),
                     )
                     .spawn()
                     .in_current_span(),
@@ -388,7 +393,11 @@ impl Watcher {
                 from,
                 tx.clone(),
                 home.clone(),
-                updates_inspected_for_double.with_label_values(&[home.name(), Self::AGENT_NAME]),
+                updates_inspected_for_double.with_label_values(&[
+                    home.name(),
+                    home.name(),
+                    Self::AGENT_NAME,
+                ]),
             )
             .spawn()
             .in_current_span();

--- a/agents/watcher/src/watcher.rs
+++ b/agents/watcher/src/watcher.rs
@@ -698,6 +698,7 @@ mod test {
             let metrics = Arc::new(
                 CoreMetrics::new(
                     "contract_sync_test",
+                    "home",
                     None,
                     Arc::new(prometheus::Registry::new()),
                 )
@@ -791,6 +792,7 @@ mod test {
             let metrics = Arc::new(
                 CoreMetrics::new(
                     "contract_sync_test",
+                    "home",
                     None,
                     Arc::new(prometheus::Registry::new()),
                 )
@@ -891,6 +893,7 @@ mod test {
             let metrics = Arc::new(
                 CoreMetrics::new(
                     "contract_sync_test",
+                    "home",
                     None,
                     Arc::new(prometheus::Registry::new()),
                 )
@@ -1093,6 +1096,7 @@ mod test {
             let metrics = Arc::new(
                 CoreMetrics::new(
                     "contract_sync_test",
+                    "home",
                     None,
                     Arc::new(prometheus::Registry::new()),
                 )
@@ -1171,6 +1175,7 @@ mod test {
                     metrics: Arc::new(
                         nomad_base::CoreMetrics::new(
                             "watcher_test",
+                            "home",
                             None,
                             Arc::new(prometheus::Registry::new()),
                         )
@@ -1284,6 +1289,7 @@ mod test {
             let metrics = Arc::new(
                 CoreMetrics::new(
                     "contract_sync_test",
+                    "home",
                     None,
                     Arc::new(prometheus::Registry::new()),
                 )
@@ -1362,6 +1368,7 @@ mod test {
                     metrics: Arc::new(
                         nomad_base::CoreMetrics::new(
                             "watcher_test",
+                            "home",
                             None,
                             Arc::new(prometheus::Registry::new()),
                         )

--- a/nomad-base/src/agent.rs
+++ b/nomad-base/src/agent.rs
@@ -228,8 +228,8 @@ pub trait NomadAgent: Send + Sync + Sized + std::fmt::Debug + AsRef<AgentCore> {
     fn watch_home_fail(&self, interval: u64) -> Instrumented<JoinHandle<Result<()>>> {
         let span = info_span!("home_watch");
         let home = self.home();
-        let home_failure_checks = self.metrics().home_failure_checks();
-        let home_failure_observations = self.metrics().home_failure_observations();
+        let home_failure_checks = self.metrics().home_failure_checks(home.name());
+        let home_failure_observations = self.metrics().home_failure_observations(home.name());
 
         tokio::spawn(async move {
             let home = home.clone();

--- a/nomad-base/src/agent.rs
+++ b/nomad-base/src/agent.rs
@@ -120,9 +120,7 @@ pub trait NomadAgent: Send + Sync + Sized + std::fmt::Debug + AsRef<AgentCore> {
     #[tracing::instrument]
     fn run_report_error(&self, replica: String) -> Instrumented<JoinHandle<Result<()>>> {
         let channel = self.build_channel(&replica);
-        let channel_faults_gauge = self
-            .metrics()
-            .channel_faults_gauge(self.home().name(), &replica);
+        let channel_faults_gauge = self.metrics().channel_faults_gauge(&replica);
 
         tokio::spawn(async move {
             let mut exponential = 0;
@@ -228,11 +226,10 @@ pub trait NomadAgent: Send + Sync + Sized + std::fmt::Debug + AsRef<AgentCore> {
     fn watch_home_fail(&self, interval: u64) -> Instrumented<JoinHandle<Result<()>>> {
         let span = info_span!("home_watch");
         let home = self.home();
-        let home_failure_checks = self.metrics().home_failure_checks(home.name());
-        let home_failure_observations = self.metrics().home_failure_observations(home.name());
+        let home_failure_checks = self.metrics().home_failure_checks();
+        let home_failure_observations = self.metrics().home_failure_observations();
 
         tokio::spawn(async move {
-            let home = home.clone();
             loop {
                 if home.state().await? == nomad_core::State::Failed {
                     home_failure_observations.inc();

--- a/nomad-base/src/contract_sync/mod.rs
+++ b/nomad-base/src/contract_sync/mod.rs
@@ -523,6 +523,7 @@ mod test {
             let metrics = Arc::new(
                 CoreMetrics::new(
                     "contract_sync_test",
+                    "home",
                     None,
                     Arc::new(prometheus::Registry::new()),
                 )

--- a/nomad-base/src/metrics.rs
+++ b/nomad-base/src/metrics.rs
@@ -11,6 +11,7 @@ use tokio::task::JoinHandle;
 /// Metrics for a particular domain
 pub struct CoreMetrics {
     agent_name: String,
+    home_name: String,
     transactions: Box<IntGaugeVec>,
     wallet_balance: Box<IntGaugeVec>,
     channel_faults: Box<IntGaugeVec>,
@@ -27,11 +28,13 @@ impl CoreMetrics {
     /// Track metrics for a particular agent name.
     pub fn new<S: Into<String>>(
         for_agent: S,
+        home_name: S,
         listen_port: Option<u16>,
         registry: Arc<Registry>,
     ) -> prometheus::Result<CoreMetrics> {
         let metrics = CoreMetrics {
             agent_name: for_agent.into(),
+            home_name: home_name.into(),
             transactions: Box::new(IntGaugeVec::new(
                 Opts::new(
                     "transactions_total",
@@ -187,21 +190,21 @@ impl CoreMetrics {
     }
 
     /// Return single gauge for one home <> replica channel
-    pub fn channel_faults_gauge(&self, home: &str, replica: &str) -> IntGauge {
+    pub fn channel_faults_gauge(&self, replica: &str) -> IntGauge {
         self.channel_faults
-            .with_label_values(&[home, replica, &self.agent_name])
+            .with_label_values(&[&self.home_name, replica, &self.agent_name])
     }
 
     /// Return home failure checks gauge
-    pub fn home_failure_checks(&self, home: &str) -> IntGauge {
+    pub fn home_failure_checks(&self) -> IntGauge {
         self.home_failure_checks
-            .with_label_values(&[home, &self.agent_name])
+            .with_label_values(&[&self.home_name, &self.agent_name])
     }
 
     /// Return home failure observations gauge
-    pub fn home_failure_observations(&self, home: &str) -> IntGauge {
+    pub fn home_failure_observations(&self) -> IntGauge {
         self.home_failure_observations
-            .with_label_values(&[home, &self.agent_name])
+            .with_label_values(&[&self.home_name, &self.agent_name])
     }
 
     /// Call with RPC duration after it is complete

--- a/nomad-base/src/settings/mod.rs
+++ b/nomad-base/src/settings/mod.rs
@@ -414,6 +414,7 @@ impl Settings {
     pub async fn try_into_core(&self, name: &str) -> Result<AgentCore, Report> {
         let metrics = Arc::new(crate::metrics::CoreMetrics::new(
             name,
+            &self.home.name,
             self.metrics,
             Arc::new(prometheus::Registry::new()),
         )?);


### PR DESCRIPTION
- straight `IntGauge` not showing up in Grafana so switch to use `IntGaugeVec`
- key watcher `IntGaugeVec` by useful contract keys