### PR TITLE
Checked tx outcome

### DIFF
--- a/agents/watcher/src/watcher.rs
+++ b/agents/watcher/src/watcher.rs
@@ -19,8 +19,8 @@ use nomad_base::{
     IndexDataTypes, NomadAgent, NomadDB,
 };
 use nomad_core::{
-    ChainCommunicationError, Common, CommonEvents, ConnectionManager, DoubleUpdate,
-    FailureNotification, Home, SignedFailureNotification, SignedUpdate, Signers, TxOutcome,
+    ChainCommunicationError, CheckedTxOutcome, Common, CommonEvents, ConnectionManager,
+    DoubleUpdate, FailureNotification, Home, SignedFailureNotification, SignedUpdate, Signers,
 };
 
 use crate::settings::WatcherSettings as Settings;
@@ -430,7 +430,7 @@ impl Watcher {
     async fn handle_double_update_failure(
         &self,
         double: &DoubleUpdate,
-    ) -> Vec<Result<TxOutcome, ChainCommunicationError>> {
+    ) -> Vec<Result<CheckedTxOutcome, ChainCommunicationError>> {
         // Create vector of double update futures
         let mut double_update_futs: Vec<_> = self
             .core
@@ -465,7 +465,7 @@ impl Watcher {
     #[tracing::instrument]
     async fn handle_improper_update_failure(
         &self,
-    ) -> Vec<Result<TxOutcome, ChainCommunicationError>> {
+    ) -> Vec<Result<CheckedTxOutcome, ChainCommunicationError>> {
         let signed_failure = self.create_signed_failure().await;
         let mut unenroll_futs = Vec::new();
         for connection_manager in self.connection_managers.iter() {
@@ -942,9 +942,8 @@ mod test {
                     .withf(move |d: &DoubleUpdate| *d == double)
                     .times(1)
                     .return_once(move |_| {
-                        Ok(TxOutcome {
+                        Ok(CheckedTxOutcome {
                             txid: H256::default(),
-                            executed: true,
                         })
                     });
             }
@@ -960,9 +959,8 @@ mod test {
                     .withf(move |d: &DoubleUpdate| *d == double)
                     .times(1)
                     .return_once(move |_| {
-                        Ok(TxOutcome {
+                        Ok(CheckedTxOutcome {
                             txid: H256::default(),
-                            executed: true,
                         })
                     });
             }
@@ -978,9 +976,8 @@ mod test {
                     .withf(move |d: &DoubleUpdate| *d == double)
                     .times(1)
                     .return_once(move |_| {
-                        Ok(TxOutcome {
+                        Ok(CheckedTxOutcome {
                             txid: H256::default(),
-                            executed: true,
                         })
                     });
             }
@@ -994,9 +991,8 @@ mod test {
                     .withf(move |f: &SignedFailureNotification| *f == signed_failure)
                     .times(1)
                     .return_once(move |_| {
-                        Ok(TxOutcome {
+                        Ok(CheckedTxOutcome {
                             txid: H256::default(),
-                            executed: true,
                         })
                     });
             }
@@ -1008,9 +1004,8 @@ mod test {
                     .withf(move |f: &SignedFailureNotification| *f == signed_failure)
                     .times(1)
                     .return_once(move |_| {
-                        Ok(TxOutcome {
+                        Ok(CheckedTxOutcome {
                             txid: H256::default(),
-                            executed: true,
                         })
                     });
             }
@@ -1148,9 +1143,8 @@ mod test {
                     .withf(move |f: &SignedFailureNotification| *f == signed_failure)
                     .times(1)
                     .return_once(move |_| {
-                        Ok(TxOutcome {
+                        Ok(CheckedTxOutcome {
                             txid: H256::default(),
-                            executed: true,
                         })
                     });
             }
@@ -1162,9 +1156,8 @@ mod test {
                     .withf(move |f: &SignedFailureNotification| *f == signed_failure)
                     .times(1)
                     .return_once(move |_| {
-                        Ok(TxOutcome {
+                        Ok(CheckedTxOutcome {
                             txid: H256::default(),
-                            executed: true,
                         })
                     });
             }

--- a/chains/nomad-ethereum/src/xapp.rs
+++ b/chains/nomad-ethereum/src/xapp.rs
@@ -81,31 +81,37 @@ where
         &self,
         replica: NomadIdentifier,
         domain: u32,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         let tx = self
             .contract
             .owner_enroll_replica(replica.as_ethereum_address(), domain);
 
-        Ok(report_tx!(tx, &self.provider).into())
+        let t: TxOutcome = report_tx!(tx, &self.provider).into();
+        t.into()
     }
 
     #[tracing::instrument(err)]
     async fn owner_unenroll_replica(
         &self,
         replica: NomadIdentifier,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         let tx = self
             .contract
             .owner_unenroll_replica(replica.as_ethereum_address());
 
-        Ok(report_tx!(tx, &self.provider).into())
+        let t: TxOutcome = report_tx!(tx, &self.provider).into();
+        t.into()
     }
 
     #[tracing::instrument(err)]
-    async fn set_home(&self, home: NomadIdentifier) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn set_home(
+        &self,
+        home: NomadIdentifier,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         let tx = self.contract.set_home(home.as_ethereum_address());
 
-        Ok(report_tx!(tx, &self.provider).into())
+        let t: TxOutcome = report_tx!(tx, &self.provider).into();
+        t.into()
     }
 
     #[tracing::instrument(err)]
@@ -114,25 +120,27 @@ where
         watcher: NomadIdentifier,
         domain: u32,
         access: bool,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         let tx =
             self.contract
                 .set_watcher_permission(watcher.as_ethereum_address(), domain, access);
 
-        Ok(report_tx!(tx, &self.provider).into())
+        let t: TxOutcome = report_tx!(tx, &self.provider).into();
+        t.into()
     }
 
     #[tracing::instrument(err)]
     async fn unenroll_replica(
         &self,
         signed_failure: &SignedFailureNotification,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         let tx = self.contract.unenroll_replica(
             signed_failure.notification.home_domain,
             signed_failure.notification.updater.into(),
             signed_failure.signature.to_vec().into(),
         );
 
-        Ok(report_tx!(tx, &self.provider).into())
+        let t: TxOutcome = report_tx!(tx, &self.provider).into();
+        t.into()
     }
 }

--- a/nomad-base/src/error.rs
+++ b/nomad-base/src/error.rs
@@ -58,10 +58,4 @@ pub enum ProcessorError {
         /// Prover leaf
         proof_leaf: H256,
     },
-    /// Transaction reverted
-    #[error("Process transaction {tx:?} was reverted.")]
-    ProcessTransactionReverted {
-        /// Hash of transaction that got reverted
-        tx: H256,
-    },
 }

--- a/nomad-base/src/home.rs
+++ b/nomad-base/src/home.rs
@@ -4,8 +4,8 @@ use color_eyre::eyre::Result;
 use ethers::core::types::H256;
 use futures_util::future::select_all;
 use nomad_core::{
-    db::DbError, ChainCommunicationError, Common, CommonEvents, DoubleUpdate, Home, HomeEvents,
-    Message, RawCommittedMessage, SignedUpdate, State, TxOutcome, Update,
+    db::DbError, ChainCommunicationError, CheckedTxOutcome, Common, CommonEvents, DoubleUpdate,
+    Home, HomeEvents, Message, RawCommittedMessage, SignedUpdate, State, Update,
 };
 use nomad_ethereum::EthereumHome;
 use nomad_test::mocks::MockHomeContract;
@@ -111,7 +111,10 @@ impl Home for CachingHome {
         self.home.nonces(destination).await
     }
 
-    async fn dispatch(&self, message: &Message) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn dispatch(
+        &self,
+        message: &Message,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self.home.dispatch(message).await
     }
 
@@ -122,7 +125,7 @@ impl Home for CachingHome {
     async fn improper_update(
         &self,
         update: &SignedUpdate,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self.home.improper_update(update).await
     }
 
@@ -176,7 +179,10 @@ impl Common for CachingHome {
         self.home.name()
     }
 
-    async fn status(&self, txid: H256) -> Result<Option<TxOutcome>, ChainCommunicationError> {
+    async fn status(
+        &self,
+        txid: H256,
+    ) -> Result<Option<CheckedTxOutcome>, ChainCommunicationError> {
         self.home.status(txid).await
     }
 
@@ -192,14 +198,17 @@ impl Common for CachingHome {
         self.home.committed_root().await
     }
 
-    async fn update(&self, update: &SignedUpdate) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn update(
+        &self,
+        update: &SignedUpdate,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self.home.update(update).await
     }
 
     async fn double_update(
         &self,
         double: &DoubleUpdate,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self.home.double_update(double).await
     }
 }
@@ -330,7 +339,10 @@ impl Home for HomeVariants {
     }
 
     #[instrument(level = "trace", err)]
-    async fn dispatch(&self, message: &Message) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn dispatch(
+        &self,
+        message: &Message,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             HomeVariants::Ethereum(home) => home.dispatch(message).await,
             HomeVariants::Mock(mock_home) => mock_home.dispatch(message).await,
@@ -349,7 +361,7 @@ impl Home for HomeVariants {
     async fn improper_update(
         &self,
         update: &SignedUpdate,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             HomeVariants::Ethereum(home) => home.improper_update(update).await,
             HomeVariants::Mock(mock_home) => mock_home.improper_update(update).await,
@@ -377,7 +389,10 @@ impl Common for HomeVariants {
         }
     }
 
-    async fn status(&self, txid: H256) -> Result<Option<TxOutcome>, ChainCommunicationError> {
+    async fn status(
+        &self,
+        txid: H256,
+    ) -> Result<Option<CheckedTxOutcome>, ChainCommunicationError> {
         match self {
             HomeVariants::Ethereum(home) => home.status(txid).await,
             HomeVariants::Mock(mock_home) => mock_home.status(txid).await,
@@ -409,7 +424,10 @@ impl Common for HomeVariants {
         }
     }
 
-    async fn update(&self, update: &SignedUpdate) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn update(
+        &self,
+        update: &SignedUpdate,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             HomeVariants::Ethereum(home) => home.update(update).await,
             HomeVariants::Mock(mock_home) => mock_home.update(update).await,
@@ -420,7 +438,7 @@ impl Common for HomeVariants {
     async fn double_update(
         &self,
         double: &DoubleUpdate,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             HomeVariants::Ethereum(home) => home.double_update(double).await,
             HomeVariants::Mock(mock_home) => mock_home.double_update(double).await,

--- a/nomad-base/src/xapp.rs
+++ b/nomad-base/src/xapp.rs
@@ -1,7 +1,7 @@
 use async_trait::async_trait;
 use nomad_core::{
-    ChainCommunicationError, ConnectionManager, NomadIdentifier, SignedFailureNotification,
-    TxOutcome,
+    ChainCommunicationError, CheckedTxOutcome, ConnectionManager, NomadIdentifier,
+    SignedFailureNotification,
 };
 
 use nomad_ethereum::EthereumConnectionManager;
@@ -98,7 +98,7 @@ impl ConnectionManager for ConnectionManagers {
         &self,
         replica: NomadIdentifier,
         domain: u32,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             ConnectionManagers::Ethereum(connection_manager) => {
                 connection_manager
@@ -121,7 +121,7 @@ impl ConnectionManager for ConnectionManagers {
     async fn owner_unenroll_replica(
         &self,
         replica: NomadIdentifier,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             ConnectionManagers::Ethereum(connection_manager) => {
                 connection_manager.owner_unenroll_replica(replica).await
@@ -135,7 +135,10 @@ impl ConnectionManager for ConnectionManagers {
         }
     }
 
-    async fn set_home(&self, home: NomadIdentifier) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn set_home(
+        &self,
+        home: NomadIdentifier,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             ConnectionManagers::Ethereum(connection_manager) => {
                 connection_manager.set_home(home).await
@@ -152,7 +155,7 @@ impl ConnectionManager for ConnectionManagers {
         watcher: NomadIdentifier,
         domain: u32,
         access: bool,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             ConnectionManagers::Ethereum(connection_manager) => {
                 connection_manager
@@ -175,7 +178,7 @@ impl ConnectionManager for ConnectionManagers {
     async fn unenroll_replica(
         &self,
         signed_failure: &SignedFailureNotification,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         match self {
             ConnectionManagers::Ethereum(connection_manager) => {
                 connection_manager.unenroll_replica(signed_failure).await

--- a/nomad-core/src/traits/home.rs
+++ b/nomad-core/src/traits/home.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use crate::{
     db::DbError,
-    traits::{ChainCommunicationError, Common, TxOutcome},
+    traits::{ChainCommunicationError, CheckedTxOutcome, Common},
     utils::home_domain_hash,
     Decode, Encode, Message, NomadError, NomadMessage, SignedUpdate, Update,
 };
@@ -119,7 +119,10 @@ pub trait Home: Common + Send + Sync + std::fmt::Debug {
     async fn nonces(&self, destination: u32) -> Result<u32, ChainCommunicationError>;
 
     /// Dispatch a message.
-    async fn dispatch(&self, message: &Message) -> Result<TxOutcome, ChainCommunicationError>;
+    async fn dispatch(
+        &self,
+        message: &Message,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 
     /// Check if queue contains root.
     async fn queue_contains(&self, root: H256) -> Result<bool, ChainCommunicationError>;
@@ -128,7 +131,7 @@ pub trait Home: Common + Send + Sync + std::fmt::Debug {
     async fn improper_update(
         &self,
         update: &SignedUpdate,
-    ) -> Result<TxOutcome, ChainCommunicationError>;
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 
     /// Create a valid update based on the chain's current state.
     /// This merely suggests an update. It does NOT ensure that no other valid

--- a/nomad-core/src/traits/replica.rs
+++ b/nomad-core/src/traits/replica.rs
@@ -4,7 +4,7 @@ use ethers::core::types::H256;
 
 use crate::{
     accumulator::merkle::Proof,
-    traits::{ChainCommunicationError, Common, TxOutcome},
+    traits::{ChainCommunicationError, CheckedTxOutcome, Common},
     NomadMessage,
 };
 
@@ -29,17 +29,20 @@ pub trait Replica: Common + Send + Sync + std::fmt::Debug {
     async fn remote_domain(&self) -> Result<u32, ChainCommunicationError>;
 
     /// Dispatch a transaction to prove inclusion of some leaf in the replica.
-    async fn prove(&self, proof: &Proof) -> Result<TxOutcome, ChainCommunicationError>;
+    async fn prove(&self, proof: &Proof) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 
     /// Trigger processing of a message
-    async fn process(&self, message: &NomadMessage) -> Result<TxOutcome, ChainCommunicationError>;
+    async fn process(
+        &self,
+        message: &NomadMessage,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 
     /// Prove a leaf in the replica and then process its message
     async fn prove_and_process(
         &self,
         message: &NomadMessage,
         proof: &Proof,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self.prove(proof).await?;
 
         Ok(self.process(message).await?)

--- a/nomad-core/src/traits/xapp.rs
+++ b/nomad-core/src/traits/xapp.rs
@@ -1,5 +1,5 @@
 use crate::{
-    traits::{ChainCommunicationError, TxOutcome},
+    traits::{ChainCommunicationError, CheckedTxOutcome},
     NomadIdentifier, SignedFailureNotification,
 };
 use async_trait::async_trait;
@@ -25,16 +25,19 @@ pub trait ConnectionManager: Send + Sync + std::fmt::Debug {
         &self,
         replica: NomadIdentifier,
         domain: u32,
-    ) -> Result<TxOutcome, ChainCommunicationError>;
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 
     /// onlyOwner function. Unenrolls replica.
     async fn owner_unenroll_replica(
         &self,
         replica: NomadIdentifier,
-    ) -> Result<TxOutcome, ChainCommunicationError>;
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 
     /// onlyOwner function. Sets contract's home to provided home.
-    async fn set_home(&self, home: NomadIdentifier) -> Result<TxOutcome, ChainCommunicationError>;
+    async fn set_home(
+        &self,
+        home: NomadIdentifier,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 
     /// onlyOwner function. Sets permission for watcher at given domain.
     async fn set_watcher_permission(
@@ -42,12 +45,12 @@ pub trait ConnectionManager: Send + Sync + std::fmt::Debug {
         watcher: NomadIdentifier,
         domain: u32,
         access: bool,
-    ) -> Result<TxOutcome, ChainCommunicationError>;
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 
     /// Unenroll the replica at the given domain provided an updater address
     /// and `SignedFailureNotification` from a watcher
     async fn unenroll_replica(
         &self,
         signed_failure: &SignedFailureNotification,
-    ) -> Result<TxOutcome, ChainCommunicationError>;
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError>;
 }

--- a/nomad-test/src/mocks/home.rs
+++ b/nomad-test/src/mocks/home.rs
@@ -33,21 +33,21 @@ mock! {
 
         pub fn _nonces(&self, destination: u32) -> Result<u32, ChainCommunicationError> {}
 
-        pub fn _dispatch(&self, message: &Message) -> Result<TxOutcome, ChainCommunicationError> {}
+        pub fn _dispatch(&self, message: &Message) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _queue_contains(&self, root: H256) -> Result<bool, ChainCommunicationError> {}
 
         pub fn _improper_update(
             &self,
             update: &SignedUpdate,
-        ) -> Result<TxOutcome, ChainCommunicationError> {}
+        ) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _produce_update(&self) -> Result<Option<Update>, ChainCommunicationError> {}
 
         // Common
         pub fn _name(&self) -> &str {}
 
-        pub fn _status(&self, txid: H256) -> Result<Option<TxOutcome>, ChainCommunicationError> {}
+        pub fn _status(&self, txid: H256) -> Result<Option<CheckedTxOutcome>, ChainCommunicationError> {}
 
         pub fn _updater(&self) -> Result<H256, ChainCommunicationError> {}
 
@@ -55,12 +55,12 @@ mock! {
 
         pub fn _committed_root(&self) -> Result<H256, ChainCommunicationError> {}
 
-        pub fn _update(&self, update: &SignedUpdate) -> Result<TxOutcome, ChainCommunicationError> {}
+        pub fn _update(&self, update: &SignedUpdate) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _double_update(
             &self,
             double: &DoubleUpdate,
-        ) -> Result<TxOutcome, ChainCommunicationError> {}
+        ) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
     }
 }
 
@@ -84,7 +84,10 @@ impl Home for MockHomeContract {
         self._nonces(destination)
     }
 
-    async fn dispatch(&self, message: &Message) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn dispatch(
+        &self,
+        message: &Message,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._dispatch(message)
     }
 
@@ -95,7 +98,7 @@ impl Home for MockHomeContract {
     async fn improper_update(
         &self,
         update: &SignedUpdate,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._improper_update(update)
     }
 
@@ -110,7 +113,10 @@ impl Common for MockHomeContract {
         self._name()
     }
 
-    async fn status(&self, txid: H256) -> Result<Option<TxOutcome>, ChainCommunicationError> {
+    async fn status(
+        &self,
+        txid: H256,
+    ) -> Result<Option<CheckedTxOutcome>, ChainCommunicationError> {
         self._status(txid)
     }
 
@@ -126,14 +132,17 @@ impl Common for MockHomeContract {
         self._committed_root()
     }
 
-    async fn update(&self, update: &SignedUpdate) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn update(
+        &self,
+        update: &SignedUpdate,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._update(update)
     }
 
     async fn double_update(
         &self,
         double: &DoubleUpdate,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._double_update(double)
     }
 }

--- a/nomad-test/src/mocks/replica.rs
+++ b/nomad-test/src/mocks/replica.rs
@@ -14,32 +14,32 @@ mock! {
 
         pub fn _remote_domain(&self) -> Result<u32, ChainCommunicationError> {}
 
-        pub fn _prove(&self, proof: &Proof) -> Result<TxOutcome, ChainCommunicationError> {}
+        pub fn _prove(&self, proof: &Proof) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
-        pub fn _process(&self, message: &NomadMessage) -> Result<TxOutcome, ChainCommunicationError> {}
+        pub fn _process(&self, message: &NomadMessage) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _prove_and_process(
             &self,
             message: &NomadMessage,
             proof: &Proof,
-        ) -> Result<TxOutcome, ChainCommunicationError> {}
+        ) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         // Common
         pub fn _name(&self) -> &str {}
 
-        pub fn _status(&self, txid: H256) -> Result<Option<TxOutcome>, ChainCommunicationError> {}
+        pub fn _status(&self, txid: H256) -> Result<Option<CheckedTxOutcome>, ChainCommunicationError> {}
 
         pub fn _updater(&self) -> Result<H256, ChainCommunicationError> {}
 
         pub fn _state(&self) -> Result<State, ChainCommunicationError> {}
 
         pub fn _committed_root(&self) -> Result<H256, ChainCommunicationError> {}
-        pub fn _update(&self, update: &SignedUpdate) -> Result<TxOutcome, ChainCommunicationError> {}
+        pub fn _update(&self, update: &SignedUpdate) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _double_update(
             &self,
             double: &DoubleUpdate,
-        ) -> Result<TxOutcome, ChainCommunicationError> {}
+        ) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _message_status(&self, leaf: H256) -> Result<MessageStatus, ChainCommunicationError> {}
 
@@ -63,11 +63,14 @@ impl Replica for MockReplicaContract {
         self._remote_domain()
     }
 
-    async fn prove(&self, proof: &Proof) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn prove(&self, proof: &Proof) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._prove(proof)
     }
 
-    async fn process(&self, message: &NomadMessage) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn process(
+        &self,
+        message: &NomadMessage,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._process(message)
     }
 
@@ -75,7 +78,7 @@ impl Replica for MockReplicaContract {
         &self,
         message: &NomadMessage,
         proof: &Proof,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._prove_and_process(message, proof)
     }
 
@@ -94,7 +97,10 @@ impl Common for MockReplicaContract {
         self._name()
     }
 
-    async fn status(&self, txid: H256) -> Result<Option<TxOutcome>, ChainCommunicationError> {
+    async fn status(
+        &self,
+        txid: H256,
+    ) -> Result<Option<CheckedTxOutcome>, ChainCommunicationError> {
         self._status(txid)
     }
 
@@ -110,14 +116,17 @@ impl Common for MockReplicaContract {
         self._committed_root()
     }
 
-    async fn update(&self, update: &SignedUpdate) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn update(
+        &self,
+        update: &SignedUpdate,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._update(update)
     }
 
     async fn double_update(
         &self,
         double: &DoubleUpdate,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._double_update(double)
     }
 }

--- a/nomad-test/src/mocks/xapp.rs
+++ b/nomad-test/src/mocks/xapp.rs
@@ -21,26 +21,26 @@ mock! {
             &self,
             replica: NomadIdentifier,
             domain: u32,
-        ) -> Result<TxOutcome, ChainCommunicationError> {}
+        ) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _owner_unenroll_replica(
             &self,
             replica: NomadIdentifier,
-        ) -> Result<TxOutcome, ChainCommunicationError> {}
+        ) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
-        pub fn _set_home(&self, home: NomadIdentifier) -> Result<TxOutcome, ChainCommunicationError> {}
+        pub fn _set_home(&self, home: NomadIdentifier) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _set_watcher_permission(
             &self,
             watcher: NomadIdentifier,
             domain: u32,
             access: bool,
-        ) -> Result<TxOutcome, ChainCommunicationError> {}
+        ) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
 
         pub fn _unenroll_replica(
             &self,
             signed_failure: &SignedFailureNotification,
-        ) -> Result<TxOutcome, ChainCommunicationError> {}
+        ) -> Result<CheckedTxOutcome, ChainCommunicationError> {}
     }
 }
 
@@ -72,18 +72,21 @@ impl ConnectionManager for MockConnectionManagerContract {
         &self,
         replica: NomadIdentifier,
         domain: u32,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._owner_enroll_replica(replica, domain)
     }
 
     async fn owner_unenroll_replica(
         &self,
         replica: NomadIdentifier,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._owner_unenroll_replica(replica)
     }
 
-    async fn set_home(&self, home: NomadIdentifier) -> Result<TxOutcome, ChainCommunicationError> {
+    async fn set_home(
+        &self,
+        home: NomadIdentifier,
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._set_home(home)
     }
 
@@ -92,14 +95,14 @@ impl ConnectionManager for MockConnectionManagerContract {
         watcher: NomadIdentifier,
         domain: u32,
         access: bool,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._set_watcher_permission(watcher, domain, access)
     }
 
     async fn unenroll_replica(
         &self,
         signed_failure: &SignedFailureNotification,
-    ) -> Result<TxOutcome, ChainCommunicationError> {
+    ) -> Result<CheckedTxOutcome, ChainCommunicationError> {
         self._unenroll_replica(signed_failure)
     }
 }


### PR DESCRIPTION
The purpose is to make a single or close to a single place where we check if transactions to the chain get executed and not reverted for instance.

- Replaced usage of `TxOutcome` with `CheckedTxOutcome`, which now doesn't have `executed` field, but being converted from `TxOutcome` -> `Result<CheckedTxOutcome>` in the core if the `executed` is `false`
- Processor had a check for the reverted transaction (implimented last weeks), but the check gets removed in favor of this PR's purpose