### PR TITLE
feature: single-field deser for signerconf and connection

### DIFF
--- a/chains/nomad-ethereum/src/macros.rs
+++ b/chains/nomad-ethereum/src/macros.rs
@@ -125,10 +125,10 @@ macro_rules! boxed_trait {
         #[doc = "Cast a contract locator to a live contract handle"]
         pub async fn $name(conn: nomad_xyz_configuration::chains::ethereum::Connection, locator: &ContractLocator, signer: Option<Signers>, timelag: Option<u8>, $($n:$t),*) -> color_eyre::Result<Box<dyn $trait>> {
             let b: Box<dyn $trait> = match conn {
-                nomad_xyz_configuration::chains::ethereum::Connection::Http { url } => {
+                nomad_xyz_configuration::chains::ethereum::Connection::Http(url) => {
                     boxed_trait!(@http url, timelag, $abi, signer, locator, $($n),*)
                 }
-                nomad_xyz_configuration::chains::ethereum::Connection::Ws { url } => {
+                nomad_xyz_configuration::chains::ethereum::Connection::Ws(url) => {
                     boxed_trait!(@ws url, timelag, $abi, signer, locator, $($n),*)
                 }
             };

--- a/configuration/src/agent/signer.rs
+++ b/configuration/src/agent/signer.rs
@@ -1,8 +1,11 @@
 use nomad_types::HexString;
+use serde::{
+    de::{self},
+    Deserialize,
+};
 
 /// Ethereum signer types
-#[derive(Debug, Clone, PartialEq, serde::Deserialize)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum SignerConf {
     /// A local hex key
     HexKey {
@@ -17,9 +20,80 @@ pub enum SignerConf {
         /// The AWS region
         region: String,
     },
-    #[serde(other)]
     /// Assume node will sign on RPC calls
     Node,
+}
+
+impl<'de> serde::Deserialize<'de> for SignerConf {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        #[derive(Deserialize)]
+        #[serde(field_identifier, rename_all = "lowercase")]
+        enum AwsField {
+            Id,
+            Region,
+        }
+
+        struct SignerConfVisitor;
+
+        impl<'de> de::Visitor<'de> for SignerConfVisitor {
+            type Value = SignerConf;
+
+            fn expecting(&self, formatter: &mut std::fmt::Formatter) -> std::fmt::Result {
+                formatter.write_str(
+                    "A 32-byte 0x-prefixed hex-key, OR an aws key id and regior OR nothing",
+                )
+            }
+
+            fn visit_str<E>(self, v: &str) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                let key = HexString::<64>::from_string(v).map_err(de::Error::custom)?;
+                Ok(SignerConf::HexKey { key })
+            }
+
+            fn visit_map<A>(self, mut map: A) -> Result<Self::Value, A::Error>
+            where
+                A: de::MapAccess<'de>,
+            {
+                let mut id: Option<String> = None;
+                let mut region: Option<String> = None;
+
+                while let Some(key) = map.next_key()? {
+                    match key {
+                        AwsField::Id => {
+                            if id.is_some() {
+                                return Err(de::Error::duplicate_field("id"));
+                            }
+                            id = Some(map.next_value()?);
+                        }
+                        AwsField::Region => {
+                            if region.is_some() {
+                                return Err(de::Error::duplicate_field("region"));
+                            }
+                            region = Some(map.next_value()?);
+                        }
+                    }
+                }
+                let id = id.ok_or_else(|| de::Error::missing_field("id"))?;
+                let region = region.ok_or_else(|| de::Error::missing_field("region"))?;
+                Ok(SignerConf::Aws { id, region })
+            }
+
+            fn visit_none<E>(self) -> Result<Self::Value, E>
+            where
+                E: de::Error,
+            {
+                Ok(SignerConf::Node)
+            }
+        }
+
+        const VARIANTS: &'static [&'static str] = &["hexkey", "aws", "node"];
+        deserializer.deserialize_enum("SignerConf", VARIANTS, SignerConfVisitor)
+    }
 }
 
 impl Default for SignerConf {

--- a/configuration/src/chains/ethereum.rs
+++ b/configuration/src/chains/ethereum.rs
@@ -1,8 +1,9 @@
 //! Ethereum/EVM configuration types
 
+use std::str::FromStr;
+
 /// Ethereum connection configuration
-#[derive(Debug, serde::Deserialize, Clone, PartialEq)]
-#[serde(tag = "type", rename_all = "camelCase")]
+#[derive(Debug, Clone, PartialEq)]
 pub enum Connection {
     /// HTTP connection details
     Http {
@@ -14,6 +15,36 @@ pub enum Connection {
         /// Fully qualified string to connect to
         url: String,
     },
+}
+
+impl Connection {
+    fn from_string(s: String) -> eyre::Result<Self> {
+        if s.starts_with("http://") || s.starts_with("https://") {
+            Ok(Self::Http { url: s })
+        } else if s.starts_with("wss://") || s.starts_with("ws://") {
+            Ok(Self::Ws { url: s })
+        } else {
+            eyre::bail!("Expected http or websocket URI")
+        }
+    }
+}
+
+impl FromStr for Connection {
+    type Err = eyre::Report;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        Self::from_string(s.to_owned())
+    }
+}
+
+impl<'de> serde::Deserialize<'de> for Connection {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        Self::from_string(s).map_err(serde::de::Error::custom)
+    }
 }
 
 impl Default for Connection {

--- a/configuration/src/chains/ethereum.rs
+++ b/configuration/src/chains/ethereum.rs
@@ -6,23 +6,23 @@ use std::str::FromStr;
 #[derive(Debug, Clone, PartialEq)]
 pub enum Connection {
     /// HTTP connection details
-    Http {
-        /// Fully qualified string to connect to
-        url: String,
-    },
+    Http(
+        /// Fully qualified URI to connect to
+        String,
+    ),
     /// Websocket connection details
-    Ws {
-        /// Fully qualified string to connect to
-        url: String,
-    },
+    Ws(
+        /// Fully qualified URI to connect to
+        String,
+    ),
 }
 
 impl Connection {
     fn from_string(s: String) -> eyre::Result<Self> {
         if s.starts_with("http://") || s.starts_with("https://") {
-            Ok(Self::Http { url: s })
+            Ok(Self::Http(s))
         } else if s.starts_with("wss://") || s.starts_with("ws://") {
-            Ok(Self::Ws { url: s })
+            Ok(Self::Ws(s))
         } else {
             eyre::bail!("Expected http or websocket URI")
         }
@@ -49,8 +49,40 @@ impl<'de> serde::Deserialize<'de> for Connection {
 
 impl Default for Connection {
     fn default() -> Self {
-        Self::Http {
-            url: Default::default(),
-        }
+        Self::Http(Default::default())
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use serde_json::json;
+
+    use super::Connection;
+
+    #[test]
+    fn it_desers_ethereum_rpc_configs() {
+        let value = json! {
+            "https://google.com"
+        };
+        let connection: Connection = serde_json::from_value(value).unwrap();
+        assert_eq!(
+            connection,
+            Connection::Http("https://google.com".to_owned())
+        );
+        let value = json! {
+            "http://google.com"
+        };
+        let connection: Connection = serde_json::from_value(value).unwrap();
+        assert_eq!(connection, Connection::Http("http://google.com".to_owned()));
+        let value = json! {
+            "wss://google.com"
+        };
+        let connection: Connection = serde_json::from_value(value).unwrap();
+        assert_eq!(connection, Connection::Ws("wss://google.com".to_owned()));
+        let value = json! {
+            "ws://google.com"
+        };
+        let connection: Connection = serde_json::from_value(value).unwrap();
+        assert_eq!(connection, Connection::Ws("ws://google.com".to_owned()));
     }
 }

--- a/fixtures/secrets.json
+++ b/fixtures/secrets.json
@@ -2,31 +2,19 @@
   "rpcs": {
     "ethereum": {
       "rpcStyle": "ethereum",
-      "connection": {
-        "type": "http",
-        "url": "https://main-light.eth.linkpool.io/"
-      }
+      "connection": "https://main-light.eth.linkpool.io/"
     },
     "moonbeam": {
       "rpcStyle": "ethereum",
-      "connection": {
-        "type": "http",
-        "url": "https://moonriver.api.onfinality.io/public"
-      }
+      "connection": "wss://moonriver.api.onfinality.io/public"
     }
   },
   "transactionSigners": {
-    "ethereum": {
-      "key": "0x1111111111111111111111111111111111111111111111111111111111111111",
-      "type": "hexKey"
-    },
+    "ethereum": "0x1111111111111111111111111111111111111111111111111111111111111111",
     "moonbeam": {
-      "key": "0x1111111111111111111111111111111111111111111111111111111111111112",
-      "type": "hexKey"
+      "id": "aws key id",
+      "region": "aws region string"
     }
   },
-  "attestationSigner": {
-    "key": "0x1111111111111111111111111111111111111111111111111111111111111113",
-    "type": "hexKey"
-  }
+  "attestationSigner": "0x1111111111111111111111111111111111111111111111111111111111111113"
 }

--- a/nomad-base/src/settings/secrets.rs
+++ b/nomad-base/src/settings/secrets.rs
@@ -79,10 +79,10 @@ impl AgentSecrets {
         for (network, chain_conf) in self.rpcs.iter() {
             match chain_conf {
                 ChainConf::Ethereum(conn) => match conn {
-                    ethereum::Connection::Http { url } => {
+                    ethereum::Connection::Http(url) => {
                         eyre::ensure!(!url.is_empty(), "Http url for {} empty!", network,);
                     }
-                    ethereum::Connection::Ws { url } => {
+                    ethereum::Connection::Ws(url) => {
                         eyre::ensure!(!url.is_empty(), "Ws url for {} empty!", network,);
                     }
                 },
@@ -91,7 +91,7 @@ impl AgentSecrets {
 
         for (network, signer_conf) in self.transaction_signers.iter() {
             match signer_conf {
-                SignerConf::HexKey { key } => {
+                SignerConf::HexKey(key) => {
                     eyre::ensure!(
                         !key.as_ref().is_empty(),
                         "Hex signer key for {} empty!",

--- a/nomad-core/src/signer.rs
+++ b/nomad-core/src/signer.rs
@@ -61,7 +61,7 @@ impl Signers {
     /// Try to build Signer from SignerConf object
     pub async fn try_from_signer_conf(conf: &SignerConf) -> Result<Self, Report> {
         match conf {
-            SignerConf::HexKey { key } => Ok(Self::Local(key.as_ref().parse()?)),
+            SignerConf::HexKey(key) => Ok(Self::Local(key.as_ref().parse()?)),
             SignerConf::Aws { id, region } => {
                 let client = KMS_CLIENT.get_or_init(|| {
                     KmsClient::new_with_client(


### PR DESCRIPTION
Changes `SignerConf` and `Connection` deserialize implementations to avoid using a second key. We achieve this by moving the differentiation logic into custom deser implementations

Old:

```
"connection": {
   "type": "ws",
   "url": "wss://....."
}
```

New:
```
"connection": "wss://...."
```


TODOs:
- [ ] tests
- [ ] update config files with better deser