### PR TITLE
fix: add_domain returns result for wasm bindings

### DIFF
--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -8,6 +8,7 @@
 - change log level to info default
 - change db path to /usr/share/nomad so persistent volumes saved
 - add_domain no longer performs config validation
+- add_domain returns Result<Option> to match wasm bindings
 
 ### v0.1.0-rc.6
 

--- a/configuration/src/lib.rs
+++ b/configuration/src/lib.rs
@@ -158,10 +158,10 @@ impl NomadConfig {
     ///
     /// This function currently clones the config. This is due to lazy
     /// programming. In the future we'll chill out on the memory usage here
-    pub fn add_domain(&mut self, network: Domain) -> Option<Domain> {
+    pub fn add_domain(&mut self, network: Domain) -> eyre::Result<Option<Domain>> {
         let name = network.name.clone();
         self.networks.insert(name.clone());
-        self.protocol.networks.insert(name, network)
+        Ok(self.protocol.networks.insert(name, network))
     }
 
     /// Add a bridge configuration to this config.


### PR DESCRIPTION
Wasm bindings can't parse returning Option. Fixes add_domain to return Result.