### PR TITLE
fix: hardcode non-fraud methods to 2x avg gas limit

### DIFF
--- a/chains/nomad-ethereum/src/home.rs
+++ b/chains/nomad-ethereum/src/home.rs
@@ -236,11 +236,14 @@ where
 
     #[tracing::instrument(err, skip(self, update), fields(update = %update))]
     async fn update(&self, update: &SignedUpdate) -> Result<TxOutcome, ChainCommunicationError> {
-        let tx = self.contract.update(
-            update.update.previous_root.to_fixed_bytes(),
-            update.update.new_root.to_fixed_bytes(),
-            update.signature.to_vec().into(),
-        );
+        let tx = self
+            .contract
+            .update(
+                update.update.previous_root.to_fixed_bytes(),
+                update.update.new_root.to_fixed_bytes(),
+                update.signature.to_vec().into(),
+            )
+            .gas(100_000);
 
         report_tx!(tx, &self.provider).try_into()
     }

--- a/chains/nomad-ethereum/src/replica.rs
+++ b/chains/nomad-ethereum/src/replica.rs
@@ -199,11 +199,14 @@ where
 
     #[tracing::instrument(err)]
     async fn update(&self, update: &SignedUpdate) -> Result<TxOutcome, ChainCommunicationError> {
-        let tx = self.contract.update(
-            update.update.previous_root.to_fixed_bytes(),
-            update.update.new_root.to_fixed_bytes(),
-            update.signature.to_vec().into(),
-        );
+        let tx = self
+            .contract
+            .update(
+                update.update.previous_root.to_fixed_bytes(),
+                update.update.new_root.to_fixed_bytes(),
+                update.signature.to_vec().into(),
+            )
+            .gas(140_000);
 
         report_tx!(tx, &self.provider).try_into()
     }
@@ -250,7 +253,8 @@ where
 
         let tx = self
             .contract
-            .prove(proof.leaf.into(), sol_proof, proof.index.into());
+            .prove(proof.leaf.into(), sol_proof, proof.index.into())
+            .gas(200_000);
 
         report_tx!(tx, &self.provider).try_into()
     }
@@ -280,7 +284,7 @@ where
         let tx = self
             .contract
             .prove_and_process(message.to_vec().into(), sol_proof, proof.index.into())
-            .gas(1_800_000);
+            .gas(1_700_000);
 
         report_tx!(tx, &self.provider).try_into()
     }


### PR DESCRIPTION
- want to avoid calling `eth_estimateGas` due to constant RPC problems
- using past estimates from indexer dataset, we've 2xed avg gas limits for all non-fraud related contract methods