### PR TITLE
fix: account for update gas variability and adjust gas limits

### DIFF
--- a/chains/nomad-ethereum/src/replica.rs
+++ b/chains/nomad-ethereum/src/replica.rs
@@ -264,7 +264,7 @@ where
         let tx = self
             .contract
             .process(message.to_vec().into())
-            .gas(1_500_000);
+            .gas(1_700_000);
 
         report_tx!(tx, &self.provider).try_into()
     }
@@ -284,7 +284,7 @@ where
         let tx = self
             .contract
             .prove_and_process(message.to_vec().into(), sol_proof, proof.index.into())
-            .gas(1_700_000);
+            .gas(1_900_000);
 
         report_tx!(tx, &self.provider).try_into()
     }

--- a/nomad-core/src/traits/home.rs
+++ b/nomad-core/src/traits/home.rs
@@ -8,7 +8,10 @@ use crate::{
 };
 use async_trait::async_trait;
 use color_eyre::Result;
-use ethers::{core::types::H256, utils::keccak256};
+use ethers::{
+    core::types::{H256, U256},
+    utils::keccak256,
+};
 
 /// A Stamped message that has been committed at some leaf index
 #[derive(Debug, Default, Clone, PartialEq)]
@@ -120,6 +123,9 @@ pub trait Home: Common + Send + Sync + std::fmt::Debug {
 
     /// Dispatch a message.
     async fn dispatch(&self, message: &Message) -> Result<TxOutcome, ChainCommunicationError>;
+
+    /// Return length of queue.
+    async fn queue_length(&self) -> Result<U256, ChainCommunicationError>;
 
     /// Check if queue contains root.
     async fn queue_contains(&self, root: H256) -> Result<bool, ChainCommunicationError>;

--- a/nomad-test/src/mocks/home.rs
+++ b/nomad-test/src/mocks/home.rs
@@ -3,7 +3,7 @@
 use async_trait::async_trait;
 use mockall::*;
 
-use ethers::core::types::H256;
+use ethers::core::types::{H256, U256};
 
 use nomad_core::*;
 
@@ -34,6 +34,8 @@ mock! {
         pub fn _nonces(&self, destination: u32) -> Result<u32, ChainCommunicationError> {}
 
         pub fn _dispatch(&self, message: &Message) -> Result<TxOutcome, ChainCommunicationError> {}
+
+        pub fn _queue_length(&self) -> Result<U256, ChainCommunicationError> {}
 
         pub fn _queue_contains(&self, root: H256) -> Result<bool, ChainCommunicationError> {}
 
@@ -86,6 +88,10 @@ impl Home for MockHomeContract {
 
     async fn dispatch(&self, message: &Message) -> Result<TxOutcome, ChainCommunicationError> {
         self._dispatch(message)
+    }
+
+    async fn queue_length(&self) -> Result<U256, ChainCommunicationError> {
+        self._queue_length()
     }
 
     async fn queue_contains(&self, root: H256) -> Result<bool, ChainCommunicationError> {


### PR DESCRIPTION
**Will go in docs repo:**
```
Update (replica), 
- 70k on average
- Double that to 140k (constant)

Prove
- 100k on average
- Double that to 200k (constant since merkle proofs always same size)

Update (home)
- Take average limit for one message (50k) and double base to 100k
- Each additional message dequeued is ~5k gas so double that cost to 10k per message
- 100k + (num_messages * 10k)

Process
- Minimum 850k required
- Double minimum 1.7M

ProveAndProcess
- 1.7M for process
- 200k for prove
- 1.9M total
```