### PR TITLE
fix(updater): roll back ethers timelag patch and add in manual update pause

### DIFF
--- a/agents/updater/src/updater.rs
+++ b/agents/updater/src/updater.rs
@@ -112,11 +112,13 @@ impl NomadAgent for Updater {
         let home = self.home();
         let address = self.signer.address();
         let db = NomadDB::new(self.home().name(), self.db());
+        let update_pause = self.as_ref().settings.home.block_time;
 
         let produce = UpdateProducer::new(
             self.home(),
             db.clone(),
             self.signer.clone(),
+            update_pause,
             self.interval_seconds,
             self.signed_attestation_count.clone(),
         );

--- a/nomad-base/src/settings/chains.rs
+++ b/nomad-base/src/settings/chains.rs
@@ -54,6 +54,8 @@ pub struct ChainSetup {
     pub page_settings: PageSettings,
     /// Network specific finality in blocks
     pub finality: u8,
+    /// Network specific block time
+    pub block_time: u64,
     /// The chain connection details
     #[serde(flatten)]
     pub chain: ChainConf,
@@ -82,6 +84,7 @@ impl ChainSetup {
             .expect("!domain");
         let domain_number = domain.domain;
         let finality = domain.specs.finalization_blocks;
+        let block_time = domain.specs.block_time;
         let core = config.core().get(&resident_network).expect("!core");
         let (address, page_settings) = match core {
             CoreContracts::Evm(core) => {
@@ -117,6 +120,7 @@ impl ChainSetup {
             address,
             page_settings,
             finality,
+            block_time,
             chain,
             disabled: None,
         }


### PR DESCRIPTION
- #100 introduced bug between timelag and nonce manager
- rolling back that bump
- having updater perform manual pause to check for unwanted state changes

Closes #103 