### PR TITLE
feat(updater): suggested updates come from syncing merkle tree to avoid updater state reads

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1185,7 +1185,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#1cc42cbba0b2fb26f0d5f45f08c19250a907225f"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
 dependencies = [
  "colored",
  "dunce",
@@ -3136,9 +3136,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.37"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
+checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
 dependencies = [
  "unicode-xid",
 ]
@@ -4015,9 +4015,9 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.1.11"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f49c1bb28a8814fdac132b1ec1f2f65c656186d8dfbc411db8bcaba45cdc06"
+checksum = "a06b8bfb6c910adbada563211b876b91a058791505e4cb646591b205fa817d01"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4107,9 +4107,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.91"
+version = "1.0.90"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
+checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4365,9 +4365,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.33"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "80b9fa4360528139bc96100c160b7ae879f5567f49f1782b0b02035b0358ebf3"
+checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
 dependencies = [
  "cfg-if 1.0.0",
  "log",

--- a/agents/updater/src/produce.rs
+++ b/agents/updater/src/produce.rs
@@ -91,7 +91,7 @@ impl UpdateProducer {
 
                 // The produced update is also confirmed state in the chain, as 
                 // home indexing timelag for dispatched messages ensures this.
-                let new_root = self.merkle_sync.tree.root();
+                let new_root = self.merkle_sync.tree.read().await.root();
 
                 // If last committed root is same as current merkle root,
                 // no update to produce

--- a/agents/updater/src/produce.rs
+++ b/agents/updater/src/produce.rs
@@ -89,9 +89,17 @@ impl UpdateProducer {
                 // the chain, as the updater indexer's timelag will ensure this.
                 let last_committed = self.latest_committed_root()?;
 
+                let merkle_read = self.merkle_sync.merkle.read().await;
+                let merkle_last_committed = merkle_read.last_committed_root();
+
+                if last_committed != merkle_last_committed {
+                    info!("Syncing merkle tree is still catching up to indexed events. Db last committed: {:?}. Merkle last committed: {:?}.", last_committed, merkle_last_committed);
+                    continue;
+                }
+
                 // The produced update is also confirmed state in the chain, as 
                 // home indexing timelag for dispatched messages ensures this.
-                let new_root = self.merkle_sync.root().await;
+                let new_root = merkle_read.root();
 
                 // If last committed root is same as current merkle root,
                 // no update to produce

--- a/agents/updater/src/produce.rs
+++ b/agents/updater/src/produce.rs
@@ -43,7 +43,10 @@ impl UpdateProducer {
     fn latest_committed_root(&self) -> Result<H256> {
         // If db latest root is empty, this will produce `H256::default()`
         // which is equal to `H256::zero()`
-        Ok(self.db.retrieve_latest_root()?.unwrap_or_default())
+        Ok(self
+            .db
+            .retrieve_latest_committed_root()?
+            .unwrap_or_default())
     }
 
     /// Store a pending update in the DB for potential submission.

--- a/agents/updater/src/produce.rs
+++ b/agents/updater/src/produce.rs
@@ -91,7 +91,7 @@ impl UpdateProducer {
 
                 // The produced update is also confirmed state in the chain, as 
                 // home indexing timelag for dispatched messages ensures this.
-                let new_root = self.merkle_sync.tree.read().await.root();
+                let new_root = self.merkle_sync.root().await;
 
                 // If last committed root is same as current merkle root,
                 // no update to produce

--- a/nomad-base/src/lib.rs
+++ b/nomad-base/src/lib.rs
@@ -27,6 +27,10 @@ pub use macros::*;
 mod nomad_db;
 pub use nomad_db::*;
 
+/// Syncing incremental merkle tree
+mod merkle_sync;
+pub use merkle_sync::*;
+
 /// Base errors
 mod error;
 pub use error::*;

--- a/nomad-base/src/merkle_sync.rs
+++ b/nomad-base/src/merkle_sync.rs
@@ -84,7 +84,7 @@ impl IncrementalMerkleSync {
         let mut tree = IncrementalMerkle::default();
         let mut last_committed_root = H256::default();
 
-        if let Some(latest_root) = db.retrieve_latest_root().expect("db error") {
+        if let Some(latest_root) = db.retrieve_latest_committed_root().expect("db error") {
             for i in 0.. {
                 match db.message_by_leaf_index(i) {
                     Ok(Some(message)) => {
@@ -120,15 +120,6 @@ impl IncrementalMerkleSync {
             db,
         }
     }
-
-    // /// Fetch the current root of the tree
-    // pub async fn root(&self) -> H256 {
-    //     self.merkle.read().await.root()
-    // }
-
-    // pub async fn last_committed_root(&self) -> H256 {
-    //     self.merkle.read().await.last_committed_root()
-    // }
 
     /// Start syncing merkle tree with DB
     pub fn sync(&self) -> Instrumented<JoinHandle<Result<()>>> {

--- a/nomad-base/src/merkle_sync.rs
+++ b/nomad-base/src/merkle_sync.rs
@@ -20,6 +20,7 @@ pub struct NomadIncrementalMerkle {
 }
 
 impl NomadIncrementalMerkle {
+    /// Instantiate new NomadIncrementalMerkle from tree and last committed root
     pub fn new(tree: IncrementalMerkle, last_committed_root: H256) -> Self {
         Self {
             tree,
@@ -120,14 +121,14 @@ impl IncrementalMerkleSync {
         }
     }
 
-    /// Fetch the current root of the tree
-    pub async fn root(&self) -> H256 {
-        self.merkle.read().await.root()
-    }
+    // /// Fetch the current root of the tree
+    // pub async fn root(&self) -> H256 {
+    //     self.merkle.read().await.root()
+    // }
 
-    pub async fn last_committed_root(&self) -> H256 {
-        self.merkle.read().await.last_committed_root()
-    }
+    // pub async fn last_committed_root(&self) -> H256 {
+    //     self.merkle.read().await.last_committed_root()
+    // }
 
     /// Start syncing merkle tree with DB
     pub fn sync(&self) -> Instrumented<JoinHandle<Result<()>>> {

--- a/nomad-base/src/merkle_sync.rs
+++ b/nomad-base/src/merkle_sync.rs
@@ -1,4 +1,5 @@
 use color_eyre::Result;
+use ethers::types::H256;
 use nomad_core::{
     accumulator::incremental::IncrementalMerkle, db::DbError, ChainCommunicationError,
 };
@@ -64,6 +65,11 @@ impl IncrementalMerkleSync {
             tree: Arc::new(RwLock::new(tree)),
             db,
         }
+    }
+
+    /// Fetch the current root of the tree
+    pub async fn root(&self) -> H256 {
+        self.tree.read().await.root()
     }
 
     /// Start syncing merkle tree with DB

--- a/nomad-base/src/merkle_sync.rs
+++ b/nomad-base/src/merkle_sync.rs
@@ -1,0 +1,92 @@
+use color_eyre::Result;
+use nomad_core::{
+    accumulator::incremental::IncrementalMerkle, db::DbError, ChainCommunicationError,
+};
+use std::time::Duration;
+use tokio::{task::JoinHandle, time::sleep};
+use tracing::{debug, error, info, info_span, instrument::Instrumented, Instrument};
+
+use crate::NomadDB;
+
+/// Self-syncing light merkle tree. Polls for new messages and updates tree.
+#[derive(Debug, Clone)]
+pub struct IncrementalMerkleSync {
+    /// Light merkle tree
+    pub tree: IncrementalMerkle,
+    /// DB with home name key prefix
+    pub db: NomadDB,
+}
+
+/// IncrementalMerkleSync errors
+#[derive(Debug, thiserror::Error)]
+pub enum IncrementalMerkleSyncError {
+    /// IncrementalMerkleSync receives ChainCommunicationError from chain API
+    #[error(transparent)]
+    ChainCommunicationError(#[from] ChainCommunicationError),
+    /// DB Error
+    #[error("{0}")]
+    DbError(#[from] DbError),
+}
+
+impl IncrementalMerkleSync {
+    /// Instantiate new IncrementalMerkleSync
+    pub fn new(db: NomadDB) -> Self {
+        Self {
+            tree: Default::default(),
+            db,
+        }
+    }
+
+    /// Instantiate new IncrementalMerkleSync from DB
+    pub fn from_disk(db: NomadDB) -> Self {
+        let mut tree = IncrementalMerkle::default();
+        if let Some(root) = db.retrieve_latest_root().expect("db error") {
+            for i in 0.. {
+                match db.leaf_by_leaf_index(i) {
+                    Ok(Some(leaf)) => {
+                        debug!(leaf_index = i, "Ingesting leaf from_disk");
+                        tree.ingest(leaf);
+                        if tree.root() == root {
+                            break;
+                        }
+                    }
+                    Ok(None) => break,
+                    Err(e) => {
+                        error!(error = %e, "Error in IncrementalMerkleSync::from_disk");
+                        panic!("Error in IncrementalMerkleSync::from_disk");
+                    }
+                }
+            }
+            info!(target_latest_root = ?root, root = ?tree.root(), "Reloaded IncrementalMerkleSync from_disk");
+        }
+
+        Self { tree, db }
+    }
+
+    /// Start syncing merkle tree with DB
+    pub fn sync(&self) -> Instrumented<JoinHandle<Result<()>>> {
+        let mut tree = self.tree.clone();
+        let db = self.db.clone();
+
+        let span = info_span!("IncrementalMerkleSync");
+        tokio::spawn(async move {
+            loop {
+                let tree_size = tree.count();
+
+                info!("Waiting for leaf at index {}...", tree_size);
+                let leaf = db.wait_for_leaf(tree_size as u32).await?;
+
+                info!(
+                    index = tree_size,
+                    leaf = ?leaf,
+                    "Ingesting leaf at index {}. Leaf: {}.",
+                    tree_size,
+                    leaf
+                );
+                tree.ingest(leaf);
+                sleep(Duration::from_secs(5)).await;
+            }
+        })
+        .instrument(span)
+    }
+}

--- a/nomad-base/src/merkle_sync.rs
+++ b/nomad-base/src/merkle_sync.rs
@@ -67,7 +67,7 @@ impl IncrementalMerkleSync {
     }
 
     /// Start syncing merkle tree with DB
-    pub fn sync(&mut self) -> Instrumented<JoinHandle<Result<()>>> {
+    pub fn sync(&self) -> Instrumented<JoinHandle<Result<()>>> {
         let tree = self.tree.clone();
         let db = self.db.clone();
 

--- a/nomad-base/src/nomad_db.rs
+++ b/nomad-base/src/nomad_db.rs
@@ -342,8 +342,26 @@ impl NomadDB {
                     return Ok(leaf);
                 }
 
-                info!("Waiting on leaf at index {}.", leaf_index);
-                sleep(Duration::from_secs(3)).await
+                debug!("Waiting on leaf at index {}.", leaf_index);
+                sleep(Duration::from_millis(100)).await
+            }
+        }
+    }
+
+    /// Poll db every 100 ms for new message by leaf index
+    pub fn wait_for_message(
+        &self,
+        leaf_index: u32,
+    ) -> impl Future<Output = Result<RawCommittedMessage, DbError>> {
+        let slf = self.clone();
+        async move {
+            loop {
+                if let Some(msg) = slf.message_by_leaf_index(leaf_index)? {
+                    return Ok(msg);
+                }
+
+                info!("Waiting on message at index {}.", leaf_index);
+                sleep(Duration::from_millis(100)).await
             }
         }
     }

--- a/nomad-base/src/nomad_db.rs
+++ b/nomad-base/src/nomad_db.rs
@@ -200,13 +200,13 @@ impl NomadDB {
     }
 
     /// Store the latest committed
-    fn store_latest_root(&self, root: H256) -> Result<(), DbError> {
+    fn store_latest_committed_root(&self, root: H256) -> Result<(), DbError> {
         debug!(root = ?root, "storing new latest root in DB");
         self.store_encodable("", LATEST_ROOT, &root)
     }
 
     /// Retrieve the latest committed
-    pub fn retrieve_latest_root(&self) -> Result<Option<H256>, DbError> {
+    pub fn retrieve_latest_committed_root(&self) -> Result<Option<H256>, DbError> {
         self.retrieve_decodable("", LATEST_ROOT)
     }
 
@@ -264,10 +264,10 @@ impl NomadDB {
 
         // If there is no latest root, or if this update is on the latest root
         // update latest root
-        match self.retrieve_latest_root()? {
+        match self.retrieve_latest_committed_root()? {
             Some(root) => {
                 if root == update.update.previous_root {
-                    self.store_latest_root(update.update.new_root)?;
+                    self.store_latest_committed_root(update.update.new_root)?;
                 } else {
                     debug!(
                         "Attempted to store update not building off latest root: {:?}",
@@ -275,7 +275,7 @@ impl NomadDB {
                     )
                 }
             }
-            None => self.store_latest_root(update.update.new_root)?,
+            None => self.store_latest_committed_root(update.update.new_root)?,
         }
 
         self.store_update(update)

--- a/nomad-base/src/nomad_db.rs
+++ b/nomad-base/src/nomad_db.rs
@@ -341,7 +341,9 @@ impl NomadDB {
                 if let Some(leaf) = slf.leaf_by_leaf_index(leaf_index)? {
                     return Ok(leaf);
                 }
-                sleep(Duration::from_millis(100)).await
+
+                info!("Waiting on leaf at index {}.", leaf_index);
+                sleep(Duration::from_secs(3)).await
             }
         }
     }

--- a/nomad-base/src/settings/mod.rs
+++ b/nomad-base/src/settings/mod.rs
@@ -89,7 +89,7 @@ impl IndexSettings {
                 use_timelag: true,
             },
             "updater" => Self {
-                data_types: IndexDataTypes::Updates,
+                data_types: IndexDataTypes::UpdatesAndMessages,
                 use_timelag: true,
             },
             "relayer" => Self {


### PR DESCRIPTION
- addressing `timelag x nonce manager` errors by removing state reads from updater
- adds syncing incremental merkle and has updater use it for producing updates
- **this will evantually become part of the home model when we do the actor-model refactor**

Closes #102 