### PR TITLE
refactor/fix: contract objects take two separate providers for reads and writes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1105,7 +1105,7 @@ dependencies = [
 [[package]]
 name = "ethers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "ethers-addressbook",
  "ethers-contract",
@@ -1120,7 +1120,7 @@ dependencies = [
 [[package]]
 name = "ethers-addressbook"
 version = "0.1.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "ethers-core",
  "once_cell",
@@ -1131,7 +1131,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-contract-derive",
@@ -1149,7 +1149,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-abigen"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "Inflector",
  "cfg-if 1.0.0",
@@ -1171,7 +1171,7 @@ dependencies = [
 [[package]]
 name = "ethers-contract-derive"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "ethers-contract-abigen",
  "ethers-core",
@@ -1185,7 +1185,7 @@ dependencies = [
 [[package]]
 name = "ethers-core"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "arrayvec 0.7.2",
  "bytes",
@@ -1211,7 +1211,7 @@ dependencies = [
 [[package]]
 name = "ethers-etherscan"
 version = "0.2.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "ethers-core",
  "ethers-solc",
@@ -1225,7 +1225,7 @@ dependencies = [
 [[package]]
 name = "ethers-middleware"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "async-trait",
  "ethers-contract",
@@ -1248,7 +1248,7 @@ dependencies = [
 [[package]]
 name = "ethers-providers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "async-trait",
  "auto_impl",
@@ -1282,7 +1282,7 @@ dependencies = [
 [[package]]
 name = "ethers-signers"
 version = "0.6.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "async-trait",
  "coins-bip32",
@@ -1303,7 +1303,7 @@ dependencies = [
 [[package]]
 name = "ethers-solc"
 version = "0.3.0"
-source = "git+https://github.com/gakonst/ethers-rs?branch=master#b3679fe113d1b51b9476d26863fd587f0755cee4"
+source = "git+https://github.com/gakonst/ethers-rs?branch=master#5f1f967ec14dc89799135c4aad67fd6647f2c84e"
 dependencies = [
  "colored",
  "dunce",
@@ -3136,9 +3136,9 @@ checksum = "dbf0c48bc1d91375ae5c3cd81e3722dff1abcf81a30960240640d223f59fe0e5"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.36"
+version = "1.0.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7342d5883fbccae1cc37a2353b09c87c9b0f3afd73f5fb9bba687a1f733b029"
+checksum = "ec757218438d5fda206afc041538b2f6d889286160d649a86a24d37e1235afd1"
 dependencies = [
  "unicode-xid",
 ]
@@ -3278,9 +3278,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c06aca804d41dbc8ba42dfd964f0d01334eceb64314b9ecf7c5fad5188a06d90"
+checksum = "fd249e82c21598a9a426a4e00dd7adc1d640b22445ec8545feef801d1a74c221"
 dependencies = [
  "autocfg",
  "crossbeam-deque",
@@ -3290,14 +3290,13 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.9.1"
+version = "1.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d78120e2c850279833f1dd3582f730c4ab53ed95aeaaaa862a2a5c71b1656d8e"
+checksum = "9f51245e1e62e1f1629cbfec37b5793bbabcaeb90f30e94d2ba03564687353e4"
 dependencies = [
  "crossbeam-channel",
  "crossbeam-deque",
  "crossbeam-utils",
- "lazy_static",
  "num_cpus",
 ]
 
@@ -4015,9 +4014,9 @@ dependencies = [
 
 [[package]]
 name = "solang-parser"
-version = "0.1.10"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a06b8bfb6c910adbada563211b876b91a058791505e4cb646591b205fa817d01"
+checksum = "e6b2ad9c159bd02219a59368133301e6195fdaa2b5d55c628ccdcd611d49235f"
 dependencies = [
  "lalrpop",
  "lalrpop-util",
@@ -4107,9 +4106,9 @@ checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
 
 [[package]]
 name = "syn"
-version = "1.0.90"
+version = "1.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704df27628939572cd88d33f171cd6f896f4eaca85252c6e0a72d8d8287ee86f"
+checksum = "b683b2b825c8eef438b77c36a06dc262294da3d5a5813fac20da149241dcd44d"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -4365,9 +4364,9 @@ checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
 
 [[package]]
 name = "tracing"
-version = "0.1.32"
+version = "0.1.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4a1bdf54a7c28a2bbf701e1d2233f6c77f473486b94bee4f9678da5a148dca7f"
+checksum = "5d0ecdcb44a79f0fe9844f0c4f33a342cbcbb5117de8001e6ba0dc2351327d09"
 dependencies = [
  "cfg-if 1.0.0",
  "log",

--- a/agents/updater/src/submit.rs
+++ b/agents/updater/src/submit.rs
@@ -38,9 +38,6 @@ impl UpdateSubmitter {
         let span = info_span!("UpdateSubmitter");
 
         tokio::spawn(async move {
-            info!(sleep = self.finalization_seconds, "Sleeping, waiting for timelagged reader to catch up.");
-            sleep(Duration::from_secs(self.finalization_seconds)).await;
-
             // start from the chain state
             let mut committed_root = self.home.committed_root().await?;
 

--- a/agents/updater/src/submit.rs
+++ b/agents/updater/src/submit.rs
@@ -38,7 +38,7 @@ impl UpdateSubmitter {
         let span = info_span!("UpdateSubmitter");
 
         tokio::spawn(async move {
-            info!("Sleeping for {} seconds waiting for timelagged reader to catch up.", self.finalization_seconds);
+            info!(sleep = self.finalization_seconds, "Sleeping, waiting for timelagged reader to catch up.");
             sleep(Duration::from_secs(self.finalization_seconds)).await;
 
             // start from the chain state
@@ -56,7 +56,7 @@ impl UpdateSubmitter {
                         new_root = ?signed.update.new_root,
                         hex_signature = %hex_signature,
                         "Submitting update to chain"
-                    );
+                );
 
                     // Submit update and let the home indexer pick up the
                     // update once it is confirmed state in the chain
@@ -71,14 +71,14 @@ impl UpdateSubmitter {
                     // timelag reader to catch up
                     info!(
                         tx_hash = ?tx.txid,
-                        "Submitted update with tx hash {:?}. Sleeping for {} seconds before next tx submission.", tx.txid, self.finalization_seconds,
+                        sleep = self.finalization_seconds,
+                        "Submitted update with tx hash {:?}. Sleeping before next tx submission.", tx.txid,
                     );
                     sleep(Duration::from_secs(self.finalization_seconds)).await;
                 } else {
                     info!(
                         committed_root = ?committed_root,
-                        "No produced update to submit for committed_root {}.",
-                        committed_root,
+                        "No produced update to submit for committed_root.",
                     )
                 }
             }

--- a/chains/nomad-ethereum/src/home.rs
+++ b/chains/nomad-ethereum/src/home.rs
@@ -3,7 +3,7 @@
 
 use async_trait::async_trait;
 use color_eyre::Result;
-use ethers::core::types::{Signature, H256, U256};
+use ethers::{middleware::TimeLag, providers::Middleware, core::types::{Signature, H256, U256}};
 use futures_util::future::join_all;
 use nomad_core::{
     ChainCommunicationError, Common, CommonIndexer, ContractLocator, DoubleUpdate, Home,
@@ -43,6 +43,7 @@ where
     /// Create new EthereumHomeIndexer
     pub fn new(
         provider: Arc<M>,
+        _read_provider: Arc<M>,
         ContractLocator {
             name: _,
             domain: _,
@@ -175,6 +176,7 @@ where
     /// chain
     pub fn new(
         provider: Arc<M>,
+        read_provider: Arc<M>,
         ContractLocator {
             name,
             domain,
@@ -184,7 +186,7 @@ where
         Self {
             contract: Arc::new(EthereumHomeInternal::new(
                 address.as_ethereum_address().expect("!eth address"),
-                provider.clone(),
+                read_provider,
             )),
             domain: *domain,
             name: name.to_owned(),

--- a/chains/nomad-ethereum/src/lib.rs
+++ b/chains/nomad-ethereum/src/lib.rs
@@ -47,23 +47,24 @@ pub struct Chain {
     ethers: ethers::providers::Provider<ethers::providers::Http>,
 }
 
-boxed_trait!(
+boxed_indexer!(
     make_home_indexer,
     EthereumHomeIndexer,
     HomeIndexer,
     from_height: u32,
     chunk_size: u32
 );
-boxed_trait!(
+boxed_indexer!(
     make_replica_indexer,
     EthereumReplicaIndexer,
     CommonIndexer,
     from_height: u32,
     chunk_size: u32
 );
-boxed_trait!(make_replica, EthereumReplica, Replica,);
-boxed_trait!(make_home, EthereumHome, Home,);
-boxed_trait!(
+
+boxed_contract!(make_replica, EthereumReplica, Replica,);
+boxed_contract!(make_home, EthereumHome, Home,);
+boxed_contract!(
     make_conn_manager,
     EthereumConnectionManager,
     ConnectionManager,

--- a/chains/nomad-ethereum/src/macros.rs
+++ b/chains/nomad-ethereum/src/macros.rs
@@ -72,7 +72,7 @@ macro_rules! log_tx_details {
 }
 
 macro_rules! boxed_trait {
-    (@finish $provider:expr, $abi:ident, $signer:ident, $($tail:tt)*) => {{
+    (@finish $provider:expr, $abi:ident, $signer:ident, $timelag:ident, $($tail:tt)*) => {{
         if let Some(signer) = $signer {
             // If there's a provided signer, we want to manage every aspect
             // locally
@@ -91,45 +91,45 @@ macro_rules! boxed_trait {
             let provider = crate::gas::GasAdjusterMiddleware::with_default_policy(provider, provider_chain_id.as_u64());
 
             // Manage signing locally
-            let signing_provider = ethers::middleware::SignerMiddleware::new(provider, signer);
+            let signing_provider = Arc::new(ethers::middleware::SignerMiddleware::new(provider, signer));
 
-            Box::new(crate::$abi::new(signing_provider.into(), $($tail)*))
+            let write_provider = Arc::new(ethers::middleware::TimeLag::new(signing_provider.clone(), 0));
+            let read_provider = if let Some(lag) = $timelag {
+                Arc::new(ethers::middleware::TimeLag::new(signing_provider, lag))
+            } else {
+                Arc::new(ethers::middleware::TimeLag::new(signing_provider, 0))
+            };
+
+            Box::new(crate::$abi::new(write_provider, read_provider, $($tail)*))
         } else {
-            Box::new(crate::$abi::new($provider, $($tail)*))
+            let write_provider = Arc::new(ethers::middleware::TimeLag::new($provider.clone(), 0));
+            let read_provider = if let Some(lag) = $timelag {
+                Arc::new(ethers::middleware::TimeLag::new($provider, lag))
+            } else {
+                Arc::new(ethers::middleware::TimeLag::new($provider, 0))
+            };
+            Box::new(crate::$abi::new(write_provider, read_provider, $($tail)*))
         }
     }};
-    (@timelag $provider:ident, $lag:ident, $($tail:tt)*) => {{
-        let provider: Arc<_> = ethers::middleware::TimeLag::new($provider, $lag).into();
-        boxed_trait!(@finish provider, $($tail)*)
-    }};
-    (@ws $url:expr, $timelag:ident, $($tail:tt)*) => {{
+    (@ws $url:expr, $($tail:tt)*) => {{
         let ws = ethers::providers::Ws::connect($url).await?;
         let provider = Arc::new(ethers::providers::Provider::new(ws));
-        if let Some(lag) = $timelag {
-            boxed_trait!(@timelag provider, lag, $($tail)*)
-        } else {
-            boxed_trait!(@finish provider, $($tail)*)
-        }
+        boxed_trait!(@finish provider, $($tail)*)
     }};
-    (@http $url:expr, $timelag:ident, $($tail:tt)*) => {{
+    (@http $url:expr, $($tail:tt)*) => {{
         let provider: crate::retrying::RetryingProvider<ethers::providers::Http> = $url.parse()?;
-        let provider = ethers::providers::Provider::new(provider);
-        let provider = Arc::new(provider);
-        if let Some(lag) = $timelag {
-            boxed_trait!(@timelag provider, lag, $($tail)*)
-        } else {
-            boxed_trait!(@finish provider, $($tail)*)
-        }
+        let provider = Arc::new(ethers::providers::Provider::new(provider));
+        boxed_trait!(@finish provider, $($tail)*)
     }};
     ($name:ident, $abi:ident, $trait:ident, $($n:ident:$t:ty),*)  => {
         #[doc = "Cast a contract locator to a live contract handle"]
         pub async fn $name(conn: nomad_xyz_configuration::chains::ethereum::Connection, locator: &ContractLocator, signer: Option<Signers>, timelag: Option<u8>, $($n:$t),*) -> color_eyre::Result<Box<dyn $trait>> {
             let b: Box<dyn $trait> = match conn {
                 nomad_xyz_configuration::chains::ethereum::Connection::Http { url } => {
-                    boxed_trait!(@http url, timelag, $abi, signer, locator, $($n),*)
+                    boxed_trait!(@http url, $abi, signer, timelag, locator, $($n),*)
                 }
                 nomad_xyz_configuration::chains::ethereum::Connection::Ws { url } => {
-                    boxed_trait!(@ws url, timelag, $abi, signer, locator, $($n),*)
+                    boxed_trait!(@ws url, $abi, signer, timelag, locator, $($n),*)
                 }
             };
             Ok(b)

--- a/chains/nomad-ethereum/src/replica.rs
+++ b/chains/nomad-ethereum/src/replica.rs
@@ -10,34 +10,30 @@ use nomad_core::{
     DoubleUpdate, Encode, MessageStatus, NomadMessage, Replica, SignedUpdate, SignedUpdateWithMeta,
     State, TxOutcome, Update, UpdateMeta,
 };
-use std::{convert::TryFrom, error::Error as StdError, marker::PhantomData, sync::Arc};
+use std::{convert::TryFrom, error::Error as StdError, sync::Arc};
 use tracing::instrument;
 
 use crate::{bindings::replica::Replica as EthereumReplicaInternal, report_tx};
 
 #[derive(Debug)]
 /// Struct that retrieves indexes event data for Ethereum replica
-pub struct EthereumReplicaIndexer<W, R>
+pub struct EthereumReplicaIndexer<R>
 where
-    W: ethers::providers::Middleware + 'static,
     R: ethers::providers::Middleware + 'static,
 {
     contract: Arc<EthereumReplicaInternal<R>>,
     provider: Arc<R>,
     from_height: u32,
     chunk_size: u32,
-    _phantom: PhantomData<W>,
 }
 
-impl<W, R> EthereumReplicaIndexer<W, R>
+impl<R> EthereumReplicaIndexer<R>
 where
-    W: ethers::providers::Middleware + 'static,
     R: ethers::providers::Middleware + 'static,
 {
     /// Create new EthereumHomeIndexer
     pub fn new(
-        _write_provider: Arc<W>,
-        read_provider: Arc<R>,
+        provider: Arc<R>,
         ContractLocator {
             name: _,
             domain: _,
@@ -49,20 +45,18 @@ where
         Self {
             contract: Arc::new(EthereumReplicaInternal::new(
                 address.as_ethereum_address().expect("!eth address"),
-                read_provider.clone(),
+                provider.clone(),
             )),
-            provider: read_provider,
+            provider,
             from_height,
             chunk_size,
-            _phantom: Default::default(),
         }
     }
 }
 
 #[async_trait]
-impl<W, R> CommonIndexer for EthereumReplicaIndexer<W, R>
+impl<R> CommonIndexer for EthereumReplicaIndexer<R>
 where
-    W: ethers::providers::Middleware + 'static,
     R: ethers::providers::Middleware + 'static,
 {
     #[instrument(err, skip(self))]

--- a/chains/nomad-ethereum/src/replica.rs
+++ b/chains/nomad-ethereum/src/replica.rs
@@ -34,6 +34,7 @@ where
     /// Create new EthereumHomeIndexer
     pub fn new(
         provider: Arc<M>,
+        _read_provider: Arc<M>,
         ContractLocator {
             name: _,
             domain: _,
@@ -138,6 +139,7 @@ where
     /// chain
     pub fn new(
         provider: Arc<M>,
+        read_provider: Arc<M>,
         ContractLocator {
             name,
             domain,

--- a/chains/nomad-ethereum/src/replica.rs
+++ b/chains/nomad-ethereum/src/replica.rs
@@ -150,11 +150,11 @@ where
         Self {
             write_contract: Arc::new(EthereumReplicaInternal::new(
                 address.as_ethereum_address().expect("!eth address"),
-                write_provider.clone(),
+                write_provider,
             )),
             read_contract: Arc::new(EthereumReplicaInternal::new(
                 address.as_ethereum_address().expect("!eth address"),
-                read_provider.clone(),
+                read_provider,
             )),
             domain: *domain,
             name: name.to_owned(),

--- a/chains/nomad-ethereum/src/xapp.rs
+++ b/chains/nomad-ethereum/src/xapp.rs
@@ -43,11 +43,11 @@ where
         Self {
             write_contract: Arc::new(EthereumConnectionManagerInternal::new(
                 address.as_ethereum_address().expect("!eth address"),
-                write_provider.clone(),
+                write_provider,
             )),
             read_contract: Arc::new(EthereumConnectionManagerInternal::new(
                 address.as_ethereum_address().expect("!eth address"),
-                read_provider.clone(),
+                read_provider,
             )),
             domain: *domain,
             name: name.to_owned(),

--- a/chains/nomad-ethereum/src/xapp.rs
+++ b/chains/nomad-ethereum/src/xapp.rs
@@ -4,7 +4,6 @@
 use async_trait::async_trait;
 use nomad_core::*;
 use nomad_types::NomadIdentifier;
-use std::marker::PhantomData;
 use std::sync::Arc;
 
 use crate::bindings::xappconnectionmanager::XAppConnectionManager as EthereumConnectionManagerInternal;
@@ -22,7 +21,6 @@ where
     read_contract: Arc<EthereumConnectionManagerInternal<R>>,
     domain: u32,
     name: String,
-    _phantom: PhantomData<W>,
 }
 
 impl<W, R> EthereumConnectionManager<W, R>
@@ -53,7 +51,6 @@ where
             )),
             domain: *domain,
             name: name.to_owned(),
-            _phantom: Default::default(),
         }
     }
 }

--- a/chains/nomad-ethereum/src/xapp.rs
+++ b/chains/nomad-ethereum/src/xapp.rs
@@ -31,6 +31,7 @@ where
     #[allow(dead_code)]
     pub fn new(
         provider: Arc<M>,
+        read_provider: Arc<M>,
         ContractLocator {
             name,
             domain,

--- a/nomad-base/src/home.rs
+++ b/nomad-base/src/home.rs
@@ -243,11 +243,12 @@ impl HomeVariants {
     }
 }
 
-impl<M> From<EthereumHome<M>> for Homes
+impl<W, R> From<EthereumHome<W, R>> for Homes
 where
-    M: ethers::providers::Middleware + 'static,
+    W: ethers::providers::Middleware + 'static,
+    R: ethers::providers::Middleware + 'static,
 {
-    fn from(home: EthereumHome<M>) -> Self {
+    fn from(home: EthereumHome<W, R>) -> Self {
         HomeVariants::Ethereum(Box::new(home)).into()
     }
 }

--- a/nomad-base/src/replica.rs
+++ b/nomad-base/src/replica.rs
@@ -201,11 +201,12 @@ impl ReplicaVariants {
     }
 }
 
-impl<M> From<EthereumReplica<M>> for Replicas
+impl<W, R> From<EthereumReplica<W, R>> for Replicas
 where
-    M: ethers::providers::Middleware + 'static,
+    W: ethers::providers::Middleware + 'static,
+    R: ethers::providers::Middleware + 'static,
 {
-    fn from(replica: EthereumReplica<M>) -> Self {
+    fn from(replica: EthereumReplica<W, R>) -> Self {
         ReplicaVariants::Ethereum(Box::new(replica)).into()
     }
 }

--- a/nomad-base/src/settings/chains.rs
+++ b/nomad-base/src/settings/chains.rs
@@ -54,6 +54,8 @@ pub struct ChainSetup {
     pub page_settings: PageSettings,
     /// Network specific finality in blocks
     pub finality: u8,
+    /// Network specific block time in seconds
+    pub block_time: u64,
     /// The chain connection details
     #[serde(flatten)]
     pub chain: ChainConf,
@@ -82,6 +84,7 @@ impl ChainSetup {
             .expect("!domain");
         let domain_number = domain.domain;
         let finality = domain.specs.finalization_blocks;
+        let block_time = domain.specs.block_time;
         let core = config.core().get(&resident_network).expect("!core");
         let (address, page_settings) = match core {
             CoreContracts::Evm(core) => {
@@ -117,6 +120,7 @@ impl ChainSetup {
             address,
             page_settings,
             finality,
+            block_time,
             chain,
             disabled: None,
         }

--- a/nomad-base/src/settings/chains.rs
+++ b/nomad-base/src/settings/chains.rs
@@ -151,11 +151,7 @@ impl ChainSetup {
     }
 
     /// Try to convert the chain setting into a replica contract
-    pub async fn try_into_replica(
-        &self,
-        signer: Option<Signers>,
-        timelag: Option<u8>,
-    ) -> Result<Replicas, Report> {
+    pub async fn try_into_replica(&self, signer: Option<Signers>) -> Result<Replicas, Report> {
         match &self.chain {
             ChainConf::Ethereum(conf) => Ok(ReplicaVariants::Ethereum(
                 make_replica(
@@ -166,7 +162,7 @@ impl ChainSetup {
                         address: self.address,
                     },
                     signer,
-                    timelag,
+                    None, // Will never need timelag for replica data/events
                 )
                 .await?,
             )

--- a/nomad-base/src/settings/mod.rs
+++ b/nomad-base/src/settings/mod.rs
@@ -360,7 +360,6 @@ impl Settings {
     /// instantiated with a built in timelag. The timelag is handled by the
     /// ContractSync.
     pub async fn try_home_indexer(&self) -> Result<HomeIndexers, Report> {
-        let signer = self.get_signer(&self.home.name).await;
         let timelag = self.home_timelag();
 
         match &self.home.chain {
@@ -372,7 +371,6 @@ impl Settings {
                         domain: self.home.domain,
                         address: self.home.address,
                     },
-                    signer,
                     timelag,
                     self.home.page_settings.from,
                     self.home.page_settings.page_size,
@@ -387,7 +385,6 @@ impl Settings {
     /// instantiated with a built in timelag. The timelag is handled by the
     /// ContractSync.
     pub async fn try_replica_indexer(&self, setup: &ChainSetup) -> Result<CommonIndexers, Report> {
-        let signer = self.get_signer(&setup.name).await;
         let timelag = self.replica_timelag(&setup.name);
 
         match &setup.chain {
@@ -399,7 +396,6 @@ impl Settings {
                         domain: setup.domain,
                         address: setup.address,
                     },
-                    signer,
                     timelag,
                     setup.page_settings.from,
                     setup.page_settings.page_size,

--- a/nomad-base/src/settings/mod.rs
+++ b/nomad-base/src/settings/mod.rs
@@ -276,11 +276,8 @@ impl Settings {
     pub async fn try_replica(&self, replica_name: &str) -> Result<Replicas, Report> {
         let replica_setup = self.replicas.get(replica_name).expect("!replica");
         let signer = self.get_signer(replica_name).await;
-        let opt_replica_timelag = self.replica_timelag(replica_name);
 
-        replica_setup
-            .try_into_replica(signer, opt_replica_timelag)
-            .await
+        replica_setup.try_into_replica(signer).await
     }
 
     /// Try to get a replica ContractSync
@@ -385,8 +382,6 @@ impl Settings {
     /// instantiated with a built in timelag. The timelag is handled by the
     /// ContractSync.
     pub async fn try_replica_indexer(&self, setup: &ChainSetup) -> Result<CommonIndexers, Report> {
-        let timelag = self.replica_timelag(&setup.name);
-
         match &setup.chain {
             ChainConf::Ethereum(conn) => Ok(CommonIndexerVariants::Ethereum(
                 make_replica_indexer(
@@ -396,7 +391,7 @@ impl Settings {
                         domain: setup.domain,
                         address: setup.address,
                     },
-                    timelag,
+                    None, // Will never need timelag for replica data/events
                     setup.page_settings.from,
                     setup.page_settings.page_size,
                 )

--- a/nomad-base/src/xapp.rs
+++ b/nomad-base/src/xapp.rs
@@ -31,11 +31,12 @@ impl ConnectionManagers {
     }
 }
 
-impl<M> From<EthereumConnectionManager<M>> for ConnectionManagers
+impl<W, R> From<EthereumConnectionManager<W, R>> for ConnectionManagers
 where
-    M: ethers::providers::Middleware + 'static,
+    W: ethers::providers::Middleware + 'static,
+    R: ethers::providers::Middleware + 'static,
 {
-    fn from(connection_manager: EthereumConnectionManager<M>) -> Self {
+    fn from(connection_manager: EthereumConnectionManager<W, R>) -> Self {
         ConnectionManagers::Ethereum(Box::new(connection_manager))
     }
 }


### PR DESCRIPTION
- ethers-rs #100 bump fixed updater timelag but did broke tx submission due to fetching timelagged nonces
- PR creates two separate providers for reads and writes for contract objects
- Also bumps ethers again to re-include the timelag fix which originally caused the timelag x nonce bug
- Removes timelag usage for replicas, as we only need it for updater safety on home and processor indexing of `Dispatch` events