### PR TITLE
style: use tokio::main macro

### DIFF
--- a/agents/kathy/src/main.rs
+++ b/agents/kathy/src/main.rs
@@ -7,13 +7,12 @@
 mod kathy;
 mod settings;
 
+use crate::{kathy::Kathy, settings::KathySettings as Settings};
 use color_eyre::Result;
-
 use nomad_base::NomadAgent;
 
-use crate::{kathy::Kathy, settings::KathySettings as Settings};
-
-async fn _main() -> Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
 
@@ -23,12 +22,4 @@ async fn _main() -> Result<()> {
     let _ = agent.metrics().run_http_server();
 
     agent.run_all().await?
-}
-
-fn main() -> Result<()> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(_main())
 }

--- a/agents/processor/src/main.rs
+++ b/agents/processor/src/main.rs
@@ -19,7 +19,8 @@ use color_eyre::Result;
 use crate::{processor::Processor, settings::ProcessorSettings as Settings};
 use nomad_base::NomadAgent;
 
-async fn _main() -> Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
 
@@ -31,12 +32,4 @@ async fn _main() -> Result<()> {
 
     agent.run_all().await??;
     Ok(())
-}
-
-fn main() -> Result<()> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(_main())
 }

--- a/agents/relayer/src/main.rs
+++ b/agents/relayer/src/main.rs
@@ -10,13 +10,12 @@
 mod relayer;
 mod settings;
 
+use crate::{relayer::Relayer, settings::RelayerSettings as Settings};
 use color_eyre::Result;
-
 use nomad_base::NomadAgent;
 
-use crate::{relayer::Relayer, settings::RelayerSettings as Settings};
-
-async fn _main() -> Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
 
@@ -28,12 +27,4 @@ async fn _main() -> Result<()> {
 
     agent.run_all().await??;
     Ok(())
-}
-
-fn main() -> Result<()> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(_main())
 }

--- a/agents/updater/src/main.rs
+++ b/agents/updater/src/main.rs
@@ -12,14 +12,12 @@ mod settings;
 mod submit;
 mod updater;
 
+use crate::{settings::UpdaterSettings as Settings, updater::Updater};
 use color_eyre::Result;
-
 use nomad_base::NomadAgent;
 
-use crate::{settings::UpdaterSettings as Settings, updater::Updater};
-
-#[allow(unused_must_use)]
-async fn _main() -> Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
 
@@ -31,12 +29,4 @@ async fn _main() -> Result<()> {
 
     agent.run_all().await??;
     Ok(())
-}
-
-fn main() -> Result<()> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(_main())
 }

--- a/agents/watcher/src/main.rs
+++ b/agents/watcher/src/main.rs
@@ -12,13 +12,12 @@
 mod settings;
 mod watcher;
 
+use crate::{settings::WatcherSettings as Settings, watcher::Watcher};
 use color_eyre::Result;
-
 use nomad_base::NomadAgent;
 
-use crate::{settings::WatcherSettings as Settings, watcher::Watcher};
-
-async fn _main() -> Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
     color_eyre::install()?;
     let settings = Settings::new()?;
 
@@ -29,12 +28,4 @@ async fn _main() -> Result<()> {
 
     agent.run_all().await??;
     Ok(())
-}
-
-fn main() -> Result<()> {
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(_main())
 }

--- a/tools/kms-cli/src/main.rs
+++ b/tools/kms-cli/src/main.rs
@@ -188,7 +188,10 @@ async fn _print_info(signer: &AwsSigner<'_>, opts: &Opts) -> Result<()> {
     Ok(())
 }
 
-async fn _main() -> Result<()> {
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<()> {
+    color_eyre::install()?;
+
     let opts: Opts = Opts::parse();
     init_kms(opts.region.to_owned());
     let chain_id = match opts.sub {
@@ -204,14 +207,4 @@ async fn _main() -> Result<()> {
         SubCommands::Transaction(_) => _send_tx(&signer, &opts).await,
         SubCommands::Info(_) => _print_info(&signer, &opts).await,
     }
-}
-
-fn main() -> Result<()> {
-    color_eyre::install()?;
-
-    tokio::runtime::Builder::new_current_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(_main())
 }


### PR DESCRIPTION
`#[tokio::main(flavor = "current_thread")]`

expands to the same runtime setup

```rust
tokio::runtime::Builder::new_current_thread()
        .enable_all()
        .build()
        .unwrap()
        .block_on(body)
```