### PR TITLE
fix: remove xdai from gui config

### DIFF
--- a/configuration/configs/production.json
+++ b/configuration/configs/production.json
@@ -538,13 +538,6 @@
       "connections": ["moonbeam", "milkomedaC1", "xDai"],
       "manualProcessing": true,
       "connextEnabled": true
-    },
-    "xdai": {
-      "displayName": "xDai",
-      "nativeTokenSymbol": "xDAI",
-      "connections": ["ethereum"],
-      "manualProcessing": false,
-      "connextEnabled": true
     }
   }
 }


### PR DESCRIPTION
We should only have networks we want to show in the GUI