### PR TITLE
feat: add Gelato Relay SDK bindings

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1543,6 +1543,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "gelato-relay"
+version = "0.1.0"
+dependencies = [
+ "async-trait",
+ "color-eyre 0.5.11",
+ "ethers",
+ "futures-util",
+ "reqwest",
+ "serde 1.0.136",
+ "serde_json",
+ "thiserror",
+ "tokio",
+]
+
+[[package]]
 name = "generic-array"
 version = "0.12.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2419,7 +2434,6 @@ dependencies = [
  "affix",
  "async-trait",
  "color-eyre 0.5.11",
- "config 0.10.1",
  "ethers",
  "futures-util",
  "lazy_static",
@@ -3414,11 +3428,13 @@ dependencies = [
  "http-body",
  "hyper",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "lazy_static",
  "log",
  "mime",
+ "native-tls",
  "percent-encoding",
  "pin-project-lite",
  "rustls",
@@ -3427,6 +3443,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "url",
  "wasm-bindgen",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,4 +17,5 @@ members = [
     "tools/kms-cli",
     "tools/nomad-cli",
     "tools/balance-exporter",
+    "gelato-relay",
 ]

--- a/gelato-relay/CHANGELOG.md
+++ b/gelato-relay/CHANGELOG.md
@@ -1,0 +1,5 @@
+# Changelog
+
+# Unreleased
+
+- adds bindings for sending relay txs, getting supported chains, and fetching task status

--- a/gelato-relay/Cargo.toml
+++ b/gelato-relay/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "gelato-relay"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+tokio = { version = "1.0.1", features = ["rt", "macros"] }
+serde = { version = "1.0", features = ["derive"] }
+serde_json = { version = "1.0", default-features = false }
+ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
+thiserror = { version = "1.0.22", default-features = false }
+async-trait = { version = "0.1.42", default-features = false }
+futures-util = "0.3.12"
+color-eyre = "0.5.0"
+reqwest = { version = "0.11.10", features = ["json"]}

--- a/gelato-relay/Cargo.toml
+++ b/gelato-relay/Cargo.toml
@@ -15,3 +15,7 @@ async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
 color-eyre = "0.5.0"
 reqwest = { version = "0.11.10", features = ["json"]}
+
+[[bin]]
+name = "test"
+path = "bin/test.rs"

--- a/gelato-relay/README.md
+++ b/gelato-relay/README.md
@@ -1,0 +1,3 @@
+## Gelato Relay SDK Bindings
+
+This crate provides Rust bindings for interacting with [Gelato's Relay SDK](https://github.com/gelatodigital/relay-sdks-monorepo/tree/07b8cec8b8370547e5632b3a6c33362df2f80125/packages/relay-sdk). It simply wraps Gelato Relay requests and responses to/from Gelato endpoints with Rust types and methods.

--- a/gelato-relay/bin/test.rs
+++ b/gelato-relay/bin/test.rs
@@ -1,0 +1,14 @@
+use gelato_relay::*;
+
+#[tokio::main(flavor = "current_thread")]
+async fn main() -> Result<(), reqwest::Error> {
+    let chains = get_gelato_relay_chains().await?;
+    println!("Relay chains: {:?}", chains);
+
+    let task_status =
+        get_task_status("0xeefc20b15402c30ead95d572034532c7097488726a6582d3d6674971e9d97879")
+            .await?;
+    println!("Task status: {:?}", task_status);
+
+    Ok(())
+}

--- a/gelato-relay/bin/test.rs
+++ b/gelato-relay/bin/test.rs
@@ -2,12 +2,14 @@ use gelato_relay::*;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<(), reqwest::Error> {
-    let chains = get_gelato_relay_chains().await?;
+    let gelato = GelatoClient::default();
+
+    let chains = gelato.get_gelato_relay_chains().await?;
     println!("Relay chains: {:?}", chains);
 
-    let task_status =
-        get_task_status("0xeefc20b15402c30ead95d572034532c7097488726a6582d3d6674971e9d97879")
-            .await?;
+    let task_status = gelato
+        .get_task_status("0xeefc20b15402c30ead95d572034532c7097488726a6582d3d6674971e9d97879")
+        .await?;
     println!("Task status: {:?}", task_status);
 
     Ok(())

--- a/gelato-relay/src/lib.rs
+++ b/gelato-relay/src/lib.rs
@@ -7,25 +7,41 @@ const RELAY_URL: &str = "https://relay.gelato.digital";
 
 pub async fn send_relay_transaction(
     chain_id: usize,
-    dest: String,
-    data: String,
-    token: String,
-    relayer_fee: String,
-) -> Result<RelayTransaction> {
+    dest: &str,
+    data: &str,
+    token: &str,
+    relayer_fee: &str,
+) -> Result<RelayResponse, reqwest::Error> {
     let params = RelayRequest {
-        dest,
-        data,
-        token,
-        relayer_fee,
+        dest: dest.to_owned(),
+        data: data.to_owned(),
+        token: token.to_owned(),
+        relayer_fee: relayer_fee.to_owned(),
     };
 
-    let client = reqwest::Client::new();
     let url = format!("{}/relays/{}", RELAY_URL, chain_id);
-    let res = client
+    let res = reqwest::Client::new()
         .post(url)
         .json(&params)
         .send()
         .await?;
 
     res.json().await
+}
+
+pub async fn is_chain_supported(chain_id: usize) -> Result<bool, reqwest::Error> {
+    let supported_chains = get_gelato_relay_chains().await?;
+    Ok(supported_chains.contains(&chain_id.to_string()))
+}
+
+pub async fn get_gelato_relay_chains() -> Result<Vec<String>, reqwest::Error> {
+    let url = format!("{}/relays", RELAY_URL);
+    let res = reqwest::get(url).await?;
+    Ok(res.json::<RelayChainsResponse>().await?.relays)
+}
+
+pub async fn get_task_status(task_id: &str) -> Result<TaskStatusResponse, reqwest::Error> {
+    let url = format!("{}/tasks/{}", RELAY_URL, task_id);
+    let res = reqwest::get(url).await?;
+    Ok(res.json().await?)
 }

--- a/gelato-relay/src/lib.rs
+++ b/gelato-relay/src/lib.rs
@@ -3,45 +3,65 @@ use types::*;
 
 use color_eyre::eyre::Result;
 
-const RELAY_URL: &str = "https://relay.gelato.digital";
+const DEFAULT_URL: &str = "https://relay.gelato.digital";
 
-pub async fn send_relay_transaction(
-    chain_id: usize,
-    dest: &str,
-    data: &str,
-    token: &str,
-    relayer_fee: &str,
-) -> Result<RelayResponse, reqwest::Error> {
-    let params = RelayRequest {
-        dest: dest.to_owned(),
-        data: data.to_owned(),
-        token: token.to_owned(),
-        relayer_fee: relayer_fee.to_owned(),
-    };
-
-    let url = format!("{}/relays/{}", RELAY_URL, chain_id);
-    let res = reqwest::Client::new()
-        .post(url)
-        .json(&params)
-        .send()
-        .await?;
-
-    res.json().await
+pub struct GelatoClient {
+    url: String,
 }
 
-pub async fn is_chain_supported(chain_id: usize) -> Result<bool, reqwest::Error> {
-    let supported_chains = get_gelato_relay_chains().await?;
-    Ok(supported_chains.contains(&chain_id.to_string()))
+impl Default for GelatoClient {
+    fn default() -> Self {
+        Self::new(DEFAULT_URL.to_owned())
+    }
 }
 
-pub async fn get_gelato_relay_chains() -> Result<Vec<String>, reqwest::Error> {
-    let url = format!("{}/relays", RELAY_URL);
-    let res = reqwest::get(url).await?;
-    Ok(res.json::<RelayChainsResponse>().await?.relays)
-}
+impl GelatoClient {
+    pub fn new(url: String) -> Self {
+        Self { url }
+    }
 
-pub async fn get_task_status(task_id: &str) -> Result<TaskStatusResponse, reqwest::Error> {
-    let url = format!("{}/tasks/{}", RELAY_URL, task_id);
-    let res = reqwest::get(url).await?;
-    Ok(res.json().await?)
+    pub async fn send_relay_transaction(
+        &self,
+        chain_id: usize,
+        dest: &str,
+        data: &str,
+        token: &str,
+        relayer_fee: &str,
+    ) -> Result<RelayResponse, reqwest::Error> {
+        let params = RelayRequest {
+            dest: dest.to_owned(),
+            data: data.to_owned(),
+            token: token.to_owned(),
+            relayer_fee: relayer_fee.to_owned(),
+        };
+
+        let url = format!("{}/relays/{}", &self.url, chain_id);
+        let res = reqwest::Client::new()
+            .post(url)
+            .json(&params)
+            .send()
+            .await?;
+
+        res.json().await
+    }
+
+    pub async fn is_chain_supported(&self, chain_id: usize) -> Result<bool, reqwest::Error> {
+        let supported_chains = self.get_gelato_relay_chains().await?;
+        Ok(supported_chains.contains(&chain_id.to_string()))
+    }
+
+    pub async fn get_gelato_relay_chains(&self) -> Result<Vec<String>, reqwest::Error> {
+        let url = format!("{}/relays", &self.url);
+        let res = reqwest::get(url).await?;
+        Ok(res.json::<RelayChainsResponse>().await?.relays)
+    }
+
+    pub async fn get_task_status(
+        &self,
+        task_id: &str,
+    ) -> Result<TaskStatusResponse, reqwest::Error> {
+        let url = format!("{}/tasks/{}", &self.url, task_id);
+        let res = reqwest::get(url).await?;
+        Ok(res.json().await?)
+    }
 }

--- a/gelato-relay/src/lib.rs
+++ b/gelato-relay/src/lib.rs
@@ -1,0 +1,31 @@
+mod types;
+use types::*;
+
+use color_eyre::eyre::Result;
+
+const RELAY_URL: &str = "https://relay.gelato.digital";
+
+pub async fn send_relay_transaction(
+    chain_id: usize,
+    dest: String,
+    data: String,
+    token: String,
+    relayer_fee: String,
+) -> Result<RelayTransaction> {
+    let params = RelayRequest {
+        dest,
+        data,
+        token,
+        relayer_fee,
+    };
+
+    let client = reqwest::Client::new();
+    let url = format!("{}/relays/{}", RELAY_URL, chain_id);
+    let res = client
+        .post(url)
+        .json(&params)
+        .send()
+        .await?;
+
+    res.json().await
+}

--- a/gelato-relay/src/types.rs
+++ b/gelato-relay/src/types.rs
@@ -1,0 +1,14 @@
+use serde::{Serialize, Deserialize};
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelayRequest {
+    pub dest: String,
+    pub data: String,
+    pub token: String,
+    pub relayer_fee: String,
+}
+
+pub struct RelayTransaction {
+    pub task_id: String
+}

--- a/gelato-relay/src/types.rs
+++ b/gelato-relay/src/types.rs
@@ -1,4 +1,4 @@
-use serde::{Serialize, Deserialize};
+use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -9,6 +9,80 @@ pub struct RelayRequest {
     pub relayer_fee: String,
 }
 
-pub struct RelayTransaction {
-    pub task_id: String
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelayResponse {
+    pub task_id: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RelayChainsResponse {
+    pub relays: Vec<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskStatusResponse {
+    data: Vec<TaskStatus>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct TaskStatus {
+    pub service: String,
+    pub chain: String,
+    pub task_id: String,
+    pub task_state: TaskState,
+    #[serde(rename = "created_at")]
+    pub created_at: String, // date
+    pub last_check: Option<String>,
+    pub execution: Option<Execution>,
+    pub last_execution: String, // date
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Execution {
+    pub status: String,
+    pub transaction_hash: String,
+    pub block_number: usize,
+    pub created_at: String,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Check {
+    pub task_state: TaskState,
+    pub message: Option<String>,
+    #[serde(rename = "created_at")]
+    pub created_at: Option<String>,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Payload {
+    pub to: String,
+    pub data: String,
+    pub fee_data: FeeData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct FeeData {
+    pub gas_price: usize,
+    pub max_fee_per_gas: usize,
+    pub max_priority_fee_per_gas: usize,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub enum TaskState {
+    CheckPending,
+    ExecPending,
+    ExecSuccess,
+    ExecReverted,
+    WaitingForConfirmation,
+    Blacklisted,
+    Cancelled,
+    NotFound,
 }

--- a/nomad-base/Cargo.toml
+++ b/nomad-base/Cargo.toml
@@ -8,7 +8,6 @@ edition = "2021"
 [dependencies]
 # Main block
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
-config = "0.10"
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }


### PR DESCRIPTION
Adds Rust bindings and types for main Gelato Relay SDK operations.
- send relay tx
- get supported chains
- fetch status of task

Closes #129