### PR TITLE
Move s3 to top-level of config 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "nomad-xyz-configuration"
-version = "0.1.0-rc.18"
+version = "0.1.0-rc.19"
 dependencies = [
  "affix",
  "dotenv",

--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -2,7 +2,7 @@ use async_trait::async_trait;
 use color_eyre::{eyre::bail, Result};
 use ethers::prelude::H256;
 use futures_util::future::select_all;
-use nomad_xyz_configuration::agent::processor::S3Config;
+use nomad_xyz_configuration::S3Config;
 use std::{
     collections::{HashMap, HashSet},
     sync::Arc,

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,10 +2,10 @@
 
 ### Unreleased
 
-- duplicate s3 bucket info at top level
-
 ### v0.1.0-rc.19
 
+- duplicate s3 bucket info at top level
+  [#151](https://github.com/nomad-xyz/rust/pull/151)
 - Simplify JSON representation of signers
 - Simplify JSON representation of connection URLs
 - Add avalanche

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- duplicate s3 bucket info at top level
+
 ### v0.1.0-rc.19
 
 - Simplify JSON representation of signers

--- a/configuration/configs/development.json
+++ b/configuration/configs/development.json
@@ -2,6 +2,10 @@
   "version": 0,
   "environment": "development",
   "networks": ["rinkeby", "goerli", "kovan", "evmostestnet"],
+  "s3": {
+    "bucket": "nomadxyz-development-proofs",
+    "region": "us-west-2"
+  },
   "rpcs": {
     "rinkeby": ["https://rinkeby-light.eth.linkpool.io"],
     "goerli": ["https://goerli-light.eth.linkpool.io"],

--- a/configuration/configs/production.json
+++ b/configuration/configs/production.json
@@ -9,6 +9,10 @@
     "milkomedaC1",
     "moonbeam"
   ],
+  "s3": {
+    "bucket": "nomadxyz-production-proofs",
+    "region": "us-west-2"
+  },
   "rpcs": {
     "evmos": ["https://eth.bd.evmos.org:8545"],
     "ethereum": ["https://main-light.eth.linkpool.io/"],

--- a/configuration/configs/staging.json
+++ b/configuration/configs/staging.json
@@ -2,6 +2,10 @@
   "version": 0,
   "environment": "staging",
   "networks": ["rinkeby", "goerli", "kovan"],
+  "s3": {
+    "bucket": "nomadxyz-development-proofs",
+    "region": "us-west-2"
+  },
   "rpcs": {
     "rinkeby": ["https://rinkeby-light.eth.linkpool.io"],
     "goerli": ["https://goerli-light.eth.linkpool.io"],

--- a/configuration/data/definitions.ts
+++ b/configuration/data/definitions.ts
@@ -177,6 +177,11 @@ export interface NomadGasConfig {
   bridge: BridgeGasConfig;
 }
 
+export interface S3Config {
+  bucket: string;
+  region: string;
+}
+
 export interface NomadConfig {
   version: number;
   environment: string;
@@ -188,4 +193,5 @@ export interface NomadConfig {
   agent: Record<string, AgentConfig>;
   gas: Record<string, NomadGasConfig>;
   bridgeGui: Record<string, AppConfig>;
+  s3?: S3Config;
 }

--- a/configuration/data/types.rs
+++ b/configuration/data/types.rs
@@ -84,6 +84,9 @@ extern "C" {
     #[wasm_bindgen(typescript_type = "NomadGasConfig")]
     pub type NomadGasConfig;
 
+    #[wasm_bindgen(typescript_type = "S3Config")]
+    pub type S3Config;
+
     #[wasm_bindgen(typescript_type = "NomadConfig")]
     pub type NomadConfig;
 }

--- a/configuration/src/agent/processor.rs
+++ b/configuration/src/agent/processor.rs
@@ -1,6 +1,6 @@
 //! Processor public configuration
 
-use crate::decl_config;
+use crate::{decl_config, S3Config};
 use ethers::types::H256;
 use std::collections::HashSet;
 
@@ -11,16 +11,7 @@ decl_config!(Processor {
     denied: Option<HashSet<H256>>,
     /// Index only mode
     subsidized_remotes: Vec<String>,
-    /// S3 config
+    /// Whether to upload proofs to s3
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     s3: Option<S3Config>,
 });
-
-/// S3 Configuration
-#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
-#[serde(rename_all = "camelCase")]
-pub struct S3Config {
-    /// Bucket
-    pub bucket: String,
-    /// Region
-    pub region: String,
-}

--- a/configuration/src/lib.rs
+++ b/configuration/src/lib.rs
@@ -41,6 +41,16 @@ use bridge::{AppConfig, BridgeContracts};
 use contracts::CoreContracts;
 use network::{Domain, NetworkInfo};
 
+/// S3 Configuration
+#[derive(Debug, Default, Clone, serde::Serialize, serde::Deserialize, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct S3Config {
+    /// Bucket
+    pub bucket: String,
+    /// Region
+    pub region: String,
+}
+
 /// A Nomad configuration json format
 #[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
 #[serde(rename_all = "camelCase")]
@@ -65,6 +75,9 @@ pub struct NomadConfig {
     gas: HashMap<String, NomadGasConfig>,
     /// Bridge application GUI configuration
     pub bridge_gui: HashMap<String, AppConfig>,
+    /// S3 bucket for this environment
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub s3: Option<S3Config>,
 }
 
 impl NomadConfig {

--- a/configuration/src/wasm/types.rs
+++ b/configuration/src/wasm/types.rs
@@ -183,6 +183,11 @@ export interface NomadGasConfig {
   bridge: BridgeGasConfig;
 }
 
+export interface S3Config {
+  bucket: string;
+  region: string;
+}
+
 export interface NomadConfig {
   version: number;
   environment: string;
@@ -194,6 +199,7 @@ export interface NomadConfig {
   agent: Record<string, AgentConfig>;
   gas: Record<string, NomadGasConfig>;
   bridgeGui: Record<string, AppConfig>;
+  s3?: S3Config;
 }
 "#;
 
@@ -282,6 +288,9 @@ extern "C" {
 
     #[wasm_bindgen(typescript_type = "NomadGasConfig")]
     pub type NomadGasConfig;
+
+    #[wasm_bindgen(typescript_type = "S3Config")]
+    pub type S3Config;
 
     #[wasm_bindgen(typescript_type = "NomadConfig")]
     pub type NomadConfig;

--- a/nomad-base/src/settings/macros.rs
+++ b/nomad-base/src/settings/macros.rs
@@ -7,6 +7,9 @@
 /// decl_settings!(Relayer, RelayerConfig,);
 /// ```
 macro_rules! decl_settings {
+    ($name:ident, $agent_settings:ty) => {
+        decl_settings!($name, $agent_settings,);
+    };
     ($name:ident, $agent_settings:ty,) => {
         affix::paste! {
             #[derive(Debug, serde::Deserialize)]
@@ -59,5 +62,5 @@ macro_rules! decl_settings {
                 }
             }
         }
-    }
+    };
 }


### PR DESCRIPTION
## Motivation

s3 info is currently deeply nested in the config, and not available to TS.

## Solution

- duplicate s3 config at top level

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
