### PR TITLE
fix: failing output tests

### DIFF
--- a/accumulator/src/lib.rs
+++ b/accumulator/src/lib.rs
@@ -4,7 +4,7 @@
 #![warn(missing_copy_implementations)]
 
 /// A full incremental merkle. Suitable for running off-chain.
-mod full;
+pub mod full;
 
 /// Hashing utils
 pub mod utils;

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- fix broken output tests
 
 ### v0.1.0-rc.21
 

--- a/nomad-core/src/test_output.rs
+++ b/nomad-core/src/test_output.rs
@@ -1,9 +1,9 @@
 use crate::{
     accumulator::{
-        merkle::{merkle_root_from_branch, MerkleTree},
+        full::{merkle_root_from_branch, MerkleTree},
         TREE_DEPTH,
     },
-    test_utils::find_vector,
+    test_utils::find_test_fixtures,
     utils::{destination_and_nonce, home_domain_hash},
     FailureNotification, NomadMessage, Update,
 };
@@ -53,7 +53,7 @@ pub mod output_functions {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(find_vector("message.json"))
+            .open(find_test_fixtures("message.json"))
             .expect("Failed to open/create file");
 
         file.write_all(json.as_bytes())
@@ -83,7 +83,7 @@ pub mod output_functions {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(find_vector("proof.json"))
+            .open(find_test_fixtures("proof.json"))
             .expect("Failed to open/create file");
 
         file.write_all(json.as_bytes())
@@ -107,7 +107,7 @@ pub mod output_functions {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(find_vector("homeDomainHash.json"))
+            .open(find_test_fixtures("homeDomainHash.json"))
             .expect("Failed to open/create file");
 
         file.write_all(json.as_bytes())
@@ -133,7 +133,7 @@ pub mod output_functions {
             .write(true)
             .create(true)
             .truncate(true)
-            .open(find_vector("destinationNonce.json"))
+            .open(find_test_fixtures("destinationNonce.json"))
             .expect("Failed to open/create file");
 
         file.write_all(json.as_bytes())
@@ -176,7 +176,7 @@ pub mod output_functions {
                 .write(true)
                 .create(true)
                 .truncate(true)
-                .open(find_vector("signedUpdate.json"))
+                .open(find_test_fixtures("signedUpdate.json"))
                 .expect("Failed to open/create file");
 
             file.write_all(json.as_bytes())
@@ -226,7 +226,7 @@ pub mod output_functions {
                 .write(true)
                 .create(true)
                 .truncate(true)
-                .open(find_vector("signedFailure.json"))
+                .open(find_test_fixtures("signedFailure.json"))
                 .expect("Failed to open/create file");
 
             file.write_all(json.as_bytes())


### PR DESCRIPTION
## Motivation

Tests behind the feature flag `output` are broken and not picked up by CI due to relaxed testing. This needs to get fixed before CI can be updated to catch all features.

Ref https://github.com/nomad-xyz/rust/issues/118

## Solution

Fix the broken tests.

## PR Checklist

- [x] Updated CHANGELOG.md for the appropriate package
