### PR TITLE
chore: update workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -25,7 +25,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Build agents
-        run: cargo build --verbose
+        run: cargo build --locked --workspace --all-features --verbose
 
   test:
     runs-on: ubuntu-latest
@@ -37,7 +37,7 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Run tests
-        run: cargo test --verbose
+        run: cargo test --locked --workspace --all-features --verbose
 
   lint:
     runs-on: ubuntu-latest
@@ -49,10 +49,10 @@ jobs:
       - uses: Swatinem/rust-cache@v1
 
       - name: Rustfmt
-        run: cargo fmt -- --check
+        run: cargo fmt --all -- --check
 
       - name: Clippy
-        run: cargo clippy -- -D warnings
+        run: cargo clippy --workspace --all-features -- -D warnings
 
   wasm-build:
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Motivation

The `cargo test` command was relaxed when being ported to the workflow from the original monorepo, causing tests behind feature flags to be skipped.

Ref https://github.com/nomad-xyz/rust/issues/118

NOTE:

**Requires https://github.com/nomad-xyz/rust/pull/165 to be pushed first or all tests will start failing**

## Solution

Make the `cargo test` and `fmt`, `clippy` and `build` commands more explicit
