### PR TITLE
refactor(updater): updater gracefully handles errors

### DIFF
--- a/agents/updater/src/updater.rs
+++ b/agents/updater/src/updater.rs
@@ -71,6 +71,20 @@ impl Updater {
     }
 }
 
+impl From<&Updater> for UpdaterChannel {
+    fn from(updater: &Updater) -> Self {
+        UpdaterChannel {
+            home: updater.home(),
+            db: NomadDB::new(updater.home().name(), updater.db()),
+            signer: updater.signer.clone(),
+            signed_attestation_count: updater.signed_attestation_count.clone(),
+            submitted_update_count: updater.submitted_update_count.clone(),
+            finalization_seconds: updater.finalization_seconds,
+            interval_seconds: updater.interval_seconds,
+        }
+    }
+}
+
 #[derive(Debug, Clone)]
 pub struct UpdaterChannel {
     home: Arc<CachingHome>,
@@ -121,15 +135,7 @@ impl NomadAgent for Updater {
     }
 
     fn build_channel(&self, _replica: &str) -> Self::Channel {
-        Self::Channel {
-            home: self.home(),
-            db: NomadDB::new(self.home().name(), self.db()),
-            signer: self.signer.clone(),
-            signed_attestation_count: self.signed_attestation_count.clone(),
-            submitted_update_count: self.submitted_update_count.clone(),
-            finalization_seconds: self.finalization_seconds,
-            interval_seconds: self.interval_seconds,
-        }
+        self.into()
     }
 
     fn run(channel: Self::Channel) -> Instrumented<JoinHandle<Result<()>>> {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

Updater currently crashes all the time when txs error out instead of handling gracefully like processor and relayer.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Apply channel/run_report_err pattern (same as relayer and processor) to updater. Updater now spawns one task for producing and submitting updates using `self.run_report_err(...)`. If tx submission errors out, that will be caught and retried with exponential backoff.

## PR Checklist

- [ ] Added Tests (N/A)
- [x] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package (N/A)
