### PR TITLE
fix: typo in goerli rpc url

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2569,7 +2569,7 @@ dependencies = [
 
 [[package]]
 name = "nomad-xyz-configuration"
-version = "0.1.0-rc.22"
+version = "0.1.0-rc.23"
 dependencies = [
  "affix",
  "dotenv",

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ### v0.1.0-rc.22
 
+- fix typo in staging goerli rpc url
+
+### v0.1.0-rc.22
+
 - fix broken output tests
 - Add Neon testnet to dev and staging configs
 

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-### v0.1.0-rc.22
+### v0.1.0-rc.23
 
 - fix typo in staging goerli rpc url
 

--- a/configuration/Cargo.toml
+++ b/configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomad-xyz-configuration"
-version = "0.1.0-rc.22"
+version = "0.1.0-rc.23"
 edition = "2021"
 authors = ["James Prestwich <james@nomad.xyz>", "The Nomad Developers <eng@nomad.xyz>"]
 description = "Nomad project configuration file utilities"

--- a/configuration/configs/staging.json
+++ b/configuration/configs/staging.json
@@ -5,7 +5,7 @@
   "rpcs": {
     "rinkeby": ["https://rinkeby-light.eth.linkpool.io"],
     "neontestnet": ["https://proxy.devnet.neonlabs.org/solana"],
-    "goerli": ["tps://goerli-light.eth.linkpool.io"],
+    "goerli": ["https://goerli-light.eth.linkpool.io"],
     "kovan": ["https://kovan.poa.network"],
     "evmostestnet": ["https://eth.bd.evmos.dev:8545"]
   },


### PR DESCRIPTION
## Motivation

goerli staging url string typo

## Solution

fix the typo

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
