### PR TITLE
Disable process retry

### DIFF
--- a/agents/processor/CHANGELOG.md
+++ b/agents/processor/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 ### Unreleased
 
+- prevent processor from retrying messages it has previously attempted to
+  process
+- improve prove/process tracing
+
 ### 1.0.0
 
 - bumps version for first release

--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -9,7 +9,9 @@ use std::{
     time::Duration,
 };
 use tokio::{sync::RwLock, task::JoinHandle, time::sleep};
-use tracing::{debug, error, info, info_span, instrument, instrument::Instrumented, Instrument, warn};
+use tracing::{
+    debug, error, info, info_span, instrument, instrument::Instrumented, warn, Instrument,
+};
 
 use nomad_base::{
     cancel_task, decl_agent, decl_channel, AgentCore, CachingHome, CachingReplica, NomadAgent,
@@ -254,7 +256,8 @@ impl Replica {
         match status {
             MessageStatus::None => {
                 info!("Submitting message for proving & processing.");
-                let result = self.replica
+                let result = self
+                    .replica
                     .prove_and_process(message.as_ref(), &proof)
                     .await;
                 if let Err(e) = result {

--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -237,6 +237,12 @@ impl Replica {
     /// Dispatch a message for processing. If the message is already proven, process only.
     async fn process(&self, message: CommittedMessage, proof: NomadProof) -> Result<()> {
         use nomad_core::Replica;
+
+        if self.db.previously_attempted(&message)? {
+            return Ok(())
+        }
+        self.db.set_previously_attempted(&message)?;
+
         let status = self.replica.message_status(message.to_leaf()).await?;
 
         match status {

--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -150,13 +150,7 @@ impl Replica {
         let message = match self.home.message_by_nonce(domain, nonce).await {
             Ok(Some(m)) => m,
             Ok(None) => {
-                info!(
-                    domain = domain,
-                    sequence = nonce,
-                    "Message not yet found {}:{}",
-                    domain,
-                    nonce,
-                );
+                info!(domain = domain, sequence = nonce, "Message not yet found",);
                 return Ok(Flow::Repeat);
             }
             Err(e) => bail!(e),
@@ -169,11 +163,9 @@ impl Replica {
         if let Some(false) = self.allowed.as_ref().map(|set| set.contains(&sender)) {
             info!(
                 sender = ?sender,
+                domain = domain,
                 nonce = nonce,
-                "Skipping message because sender not on allow list. Sender: {}. Domain: {}. Nonce: {}",
-                sender,
-                domain,
-                nonce
+                "Skipping message because sender not on allow list."
             );
             return Ok(Flow::Advance);
         }
@@ -182,11 +174,9 @@ impl Replica {
         if let Some(true) = self.denied.as_ref().map(|set| set.contains(&sender)) {
             info!(
                 sender = ?sender,
+                domain = domain,
                 nonce = nonce,
-                "Skipping message because sender on deny list. Sender: {}. Domain: {}. Nonce: {}",
-                sender,
-                domain,
-                nonce
+                "Skipping message because sender on deny list."
             );
             return Ok(Flow::Advance);
         }
@@ -254,7 +244,8 @@ impl Replica {
 
         // We don't care if the prove/process succeeds. We just want it to be
         // dispatched to the chain. We'll still log warnings if they fail
-        const PROCESS_ERR_MESSAGE: &str = "Error in processing. May indicate an internal revert of the handler.";
+        const PROCESS_ERR_MESSAGE: &str =
+            "Error in processing. May indicate an internal revert of the handler.";
         match status {
             MessageStatus::None => {
                 info!("Submitting message for proving & processing.");

--- a/chains/nomad-ethereum/src/macros.rs
+++ b/chains/nomad-ethereum/src/macros.rs
@@ -28,8 +28,8 @@ macro_rules! report_tx {
             .await?;
 
         tracing::info!(
-            "confirmed transaction with tx_hash {:?}",
-            result.transaction_hash
+            tx_hash = ?result.transaction_hash,
+            "Confirmed transaction",
         );
 
         result
@@ -50,8 +50,8 @@ macro_rules! report_tx {
             .ok_or_else(|| nomad_core::ChainCommunicationError::DroppedError(tx_hash))?;
 
         tracing::info!(
-            "confirmed transaction with tx_hash {:?}",
-            result.transaction_hash
+            tx_hash = ?tx_hash,
+            "Confirmed transaction",
         );
 
         result

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ### Unreleased
 
+- add `previously_attempted` to the DB schema
 - adds a changelog

--- a/nomad-base/src/nomad_db.rs
+++ b/nomad-base/src/nomad_db.rs
@@ -13,17 +13,18 @@ use std::time::Duration;
 
 use nomad_core::db::iterator::PrefixIterator;
 
-static LEAF_IDX: &str = "leaf_index_";
-static LEAF: &str = "leaf_";
-static PREV_ROOT: &str = "update_prev_root_";
-static PROOF: &str = "proof_";
-static MESSAGE: &str = "message_";
-static UPDATE: &str = "update_";
-static UPDATE_META: &str = "update_metadata_";
-static LATEST_ROOT: &str = "update_latest_root_";
-static LATEST_LEAF_INDEX: &str = "latest_known_leaf_index_";
-static UPDATER_PRODUCED_UPDATE: &str = "updater_produced_update_";
-static PROVER_LATEST_COMMITTED: &str = "prover_latest_committed_";
+const LEAF_IDX: &str = "leaf_index_";
+const LEAF: &str = "leaf_";
+const PREV_ROOT: &str = "update_prev_root_";
+const PROOF: &str = "proof_";
+const MESSAGE: &str = "message_";
+const UPDATE: &str = "update_";
+const UPDATE_META: &str = "update_metadata_";
+const LATEST_ROOT: &str = "update_latest_root_";
+const LATEST_LEAF_INDEX: &str = "latest_known_leaf_index_";
+const UPDATER_PRODUCED_UPDATE: &str = "updater_produced_update_";
+const PROVER_LATEST_COMMITTED: &str = "prover_latest_committed_";
+const PROCESSOR_ATTEMPTED: &str = "processor_attempted_";
 
 /// DB handle for storing data tied to a specific home.
 ///
@@ -373,6 +374,22 @@ impl NomadDB {
     pub fn retrieve_prover_latest_committed(&self) -> Result<Option<H256>, DbError> {
         self.retrieve_decodable("", PROVER_LATEST_COMMITTED)
     }
+
+    /// Set a DB entry stating that the processor has previously attempted to
+    /// process a message
+    pub fn set_previously_attempted(&self, message: &CommittedMessage) -> Result<(), DbError> {
+        self.store_encodable(PROCESSOR_ATTEMPTED, message.to_leaf(), &true)
+    }
+
+    /// Returns `true` if the processor has previously attempted to process the
+    /// mesage
+    pub fn previously_attempted(&self, message: &CommittedMessage) -> Result<bool, DbError> {
+        match self.retrieve_decodable(PROCESSOR_ATTEMPTED, message.to_leaf())? {
+            Some(inner) => Ok(inner),
+            None => Ok(false),
+        }
+    }
+
 }
 
 #[cfg(test)]

--- a/nomad-base/src/nomad_db.rs
+++ b/nomad-base/src/nomad_db.rs
@@ -389,7 +389,6 @@ impl NomadDB {
             None => Ok(false),
         }
     }
-
 }
 
 #[cfg(test)]

--- a/nomad-core/CHANGELOG.md
+++ b/nomad-core/CHANGELOG.md
@@ -2,4 +2,5 @@
 
 ### Unreleased
 
+- implement `Encode` and `Decode` for `bool`
 - adds a changelog

--- a/nomad-core/src/traits/encode.rs
+++ b/nomad-core/src/traits/encode.rs
@@ -153,11 +153,11 @@ impl<const N: usize> Decode for accumulator::Proof<N> {
     }
 }
 
-
 impl Encode for bool {
     fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
     where
-        W: std::io::Write {
+        W: std::io::Write,
+    {
         writer.write_all(&[(*self).into()])?;
         Ok(1)
     }
@@ -167,8 +167,9 @@ impl Decode for bool {
     fn read_from<R>(reader: &mut R) -> Result<Self, NomadError>
     where
         R: std::io::Read,
-        Self: Sized {
-        let mut buf = [0u8;1];
+        Self: Sized,
+    {
+        let mut buf = [0u8; 1];
         reader.read_exact(&mut buf)?;
 
         match buf[0] {

--- a/nomad-core/src/traits/encode.rs
+++ b/nomad-core/src/traits/encode.rs
@@ -152,3 +152,28 @@ impl<const N: usize> Decode for accumulator::Proof<N> {
         Ok(Self { leaf, index, path })
     }
 }
+
+
+impl Encode for bool {
+    fn write_to<W>(&self, writer: &mut W) -> std::io::Result<usize>
+    where
+        W: std::io::Write {
+        writer.write_all(&[(*self).into()])?;
+        Ok(1)
+    }
+}
+
+impl Decode for bool {
+    fn read_from<R>(reader: &mut R) -> Result<Self, NomadError>
+    where
+        R: std::io::Read,
+        Self: Sized {
+        let mut buf = [0u8;1];
+        reader.read_exact(&mut buf)?;
+
+        match buf[0] {
+            0 => Ok(false),
+            _ => Ok(true),
+        }
+    }
+}


### PR DESCRIPTION
## Motivation

Next version of replica will allow processing to fail, reverting the tx entirely. The process currently cannot handle that. There are two problems

1. The processor will error if the `process` call errors
2. The processor will re-attempt errored `process` calls on next reboot 

## Solution

- Store a bool in the DB when the processor attempts to prove/process a message
- Do not re-attempt messages that were previously attempted
- Do not error if process transactions error
- Enhanced logging for the prove/process flow

This prevents the processor from erroring on failed `process` calls. It also ensures that a failed call will not be re-attempted

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package


cc @anna-carroll for visibility