### PR TITLE
Remove gnosis chain from prod gui

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2640,7 +2640,7 @@ dependencies = [
 
 [[package]]
 name = "nomad-xyz-configuration"
-version = "0.1.0-rc.24"
+version = "0.1.0-rc.25"
 dependencies = [
  "affix",
  "dotenv",

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,9 +2,12 @@
 
 ### Unreleased
 
+### v0.1.0-rc.25
+
 - adds transaction submitters type to replace transaction signers
 - adds gelato config struct
 - uses correct staging s3 bucket in staging environment
+- remove gnosis chain from list of bridgeGUI networks
 
 ### v0.1.0-rc.24
 

--- a/configuration/Cargo.toml
+++ b/configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomad-xyz-configuration"
-version = "0.1.0-rc.24"
+version = "0.1.0-rc.25"
 edition = "2021"
 authors = ["James Prestwich <james@nomad.xyz>", "The Nomad Developers <eng@nomad.xyz>"]
 description = "Nomad project configuration file utilities"

--- a/configuration/configs/production.json
+++ b/configuration/configs/production.json
@@ -928,12 +928,6 @@
       "nativeTokenSymbol": "milkADA",
       "connections": ["ethereum"]
     },
-    "xdai": {
-      "displayName": "Gnosis Chain",
-      "nativeTokenSymbol": "xDAI",
-      "connections": ["ethereum"],
-      "connextEnabled": true
-    },
     "moonbeam": {
       "displayName": "Moonbeam",
       "nativeTokenSymbol": "GLMR",

--- a/configuration/configs/production.json
+++ b/configuration/configs/production.json
@@ -904,6 +904,13 @@
     "avalanche": "evmDefault"
   },
   "bridgeGui": {
+    "ethereum": {
+      "displayName": "Ethereum",
+      "nativeTokenSymbol": "ETH",
+      "connections": ["avalanche", "moonbeam", "milkomedaC1", "xDai"],
+      "manualProcessing": true,
+      "connextEnabled": true
+    },
     "avalanche": {
       "displayName": "Avalanche",
       "nativeTokenSymbol": "AVAX",
@@ -914,13 +921,6 @@
       "displayName": "Evmos",
       "nativeTokenSymbol": "EVMOS",
       "connections": ["ethereum"],
-      "connextEnabled": true
-    },
-    "ethereum": {
-      "displayName": "Ethereum",
-      "nativeTokenSymbol": "ETH",
-      "connections": ["avalanche", "moonbeam", "milkomedaC1", "xDai"],
-      "manualProcessing": true,
       "connextEnabled": true
     },
     "milkomedaC1": {


### PR DESCRIPTION
## Motivation

Don't show gnosis in prod gui just yet

## Solution

Remove gnosis from the bridgeGUI section

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
