### PR TITLE
fix: add evmos connection to ethereum

### DIFF
--- a/configuration/configs/production.json
+++ b/configuration/configs/production.json
@@ -907,7 +907,7 @@
     "ethereum": {
       "displayName": "Ethereum",
       "nativeTokenSymbol": "ETH",
-      "connections": ["avalanche", "moonbeam", "milkomedaC1", "xDai"],
+      "connections": ["avalanche", "moonbeam", "milkomedaC1", "evmos"],
       "manualProcessing": true,
       "connextEnabled": true
     },


### PR DESCRIPTION
Evmos accidentally removed from list of Ethereum connections

## Motivation

Fix asap

## Solution

Add to list

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
