### PR TITLE
fix(config): lower per-message gas hardcode

### DIFF
--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - feature: pull config files from github pages instead of local versions
+- lower per-message gas hardcode for home:update calls
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides
 - remove `enabled` flag from agents project-wide

--- a/configuration/src/gas/defaults.rs
+++ b/configuration/src/gas/defaults.rs
@@ -7,7 +7,7 @@ pub const EVM_DEFAULT: NomadGasConfig = NomadGasConfig {
     core: CoreGasConfig {
         home: HomeGasLimits {
             update: HomeUpdateGasLimit {
-                per_message: 10_000,
+                per_message: 2_000,
                 base: 100_000,
             },
             improper_update: HomeUpdateGasLimit {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

Gas estimate hardcodes generally a bit high. Causes extremely high estimates for devnets due to high number of messages being constantly enqueued.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Remove evmDefault hardcodes where not necessary (only needed on Moonbeam, Milkomeda, and xDai given past history). Also lower per-message gas hardcode for home:update.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
