### PR TITLE
fix: update agent ABI and remove double-update

### DIFF
--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -249,7 +249,7 @@ impl Replica {
         // dispatched to the chain. We'll still log warnings if they fail
         let fut = match status {
             MessageStatus::None => self.replica.prove_and_process(message.as_ref(), &proof),
-            MessageStatus::Proven => self.replica.process(message.as_ref()),
+            MessageStatus::Proven(_) => self.replica.process(message.as_ref()),
             _ => unreachable!(),
         };
         info!("Submitting message for processing");

--- a/chains/nomad-ethereum/abis/Replica.abi.json
+++ b/chains/nomad-ethereum/abis/Replica.abi.json
@@ -5,51 +5,10 @@
         "internalType": "uint32",
         "name": "_localDomain",
         "type": "uint32"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_processGas",
-        "type": "uint256"
-      },
-      {
-        "internalType": "uint256",
-        "name": "_reserveGas",
-        "type": "uint256"
       }
     ],
     "stateMutability": "nonpayable",
     "type": "constructor"
-  },
-  {
-    "anonymous": false,
-    "inputs": [
-      {
-        "indexed": false,
-        "internalType": "bytes32",
-        "name": "oldRoot",
-        "type": "bytes32"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes32[2]",
-        "name": "newRoot",
-        "type": "bytes32[2]"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "signature",
-        "type": "bytes"
-      },
-      {
-        "indexed": false,
-        "internalType": "bytes",
-        "name": "signature2",
-        "type": "bytes"
-      }
-    ],
-    "name": "DoubleUpdate",
-    "type": "event"
   },
   {
     "anonymous": false,
@@ -185,12 +144,12 @@
   },
   {
     "inputs": [],
-    "name": "PROCESS_GAS",
+    "name": "LEGACY_STATUS_NONE",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "bytes32",
         "name": "",
-        "type": "uint256"
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",
@@ -198,12 +157,25 @@
   },
   {
     "inputs": [],
-    "name": "RESERVE_GAS",
+    "name": "LEGACY_STATUS_PROCESSED",
     "outputs": [
       {
-        "internalType": "uint256",
+        "internalType": "bytes32",
         "name": "",
-        "type": "uint256"
+        "type": "bytes32"
+      }
+    ],
+    "stateMutability": "view",
+    "type": "function"
+  },
+  {
+    "inputs": [],
+    "name": "LEGACY_STATUS_PROVEN",
+    "outputs": [
+      {
+        "internalType": "bytes32",
+        "name": "",
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",
@@ -274,34 +246,6 @@
     "type": "function"
   },
   {
-    "inputs": [
-      {
-        "internalType": "bytes32",
-        "name": "_oldRoot",
-        "type": "bytes32"
-      },
-      {
-        "internalType": "bytes32[2]",
-        "name": "_newRoot",
-        "type": "bytes32[2]"
-      },
-      {
-        "internalType": "bytes",
-        "name": "_signature",
-        "type": "bytes"
-      },
-      {
-        "internalType": "bytes",
-        "name": "_signature2",
-        "type": "bytes"
-      }
-    ],
-    "name": "doubleUpdate",
-    "outputs": [],
-    "stateMutability": "nonpayable",
-    "type": "function"
-  },
-  {
     "inputs": [],
     "name": "homeDomainHash",
     "outputs": [
@@ -366,9 +310,9 @@
     "name": "messages",
     "outputs": [
       {
-        "internalType": "enum Replica.MessageStatus",
+        "internalType": "bytes32",
         "name": "",
-        "type": "uint8"
+        "type": "bytes32"
       }
     ],
     "stateMutability": "view",

--- a/chains/nomad-ethereum/src/bindings/replica.rs
+++ b/chains/nomad-ethereum/src/bindings/replica.rs
@@ -18,7 +18,7 @@ mod replica_mod {
     use std::sync::Arc;
     pub static REPLICA_ABI: ethers::contract::Lazy<ethers::core::abi::Abi> =
         ethers::contract::Lazy::new(|| {
-            serde_json :: from_str ("[\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"_localDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_processGas\",\n        \"type\": \"uint256\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_reserveGas\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"constructor\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": false,\n        \"internalType\": \"bytes32\",\n        \"name\": \"oldRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"bytes32[2]\",\n        \"name\": \"newRoot\",\n        \"type\": \"bytes32[2]\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"bytes\",\n        \"name\": \"signature\",\n        \"type\": \"bytes\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"bytes\",\n        \"name\": \"signature2\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"DoubleUpdate\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": false,\n        \"internalType\": \"address\",\n        \"name\": \"oldUpdater\",\n        \"type\": \"address\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"address\",\n        \"name\": \"newUpdater\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"NewUpdater\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"address\",\n        \"name\": \"previousOwner\",\n        \"type\": \"address\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"address\",\n        \"name\": \"newOwner\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"OwnershipTransferred\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"messageHash\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bool\",\n        \"name\": \"success\",\n        \"type\": \"bool\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes\",\n        \"name\": \"returnData\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"Process\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"root\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"uint256\",\n        \"name\": \"previousConfirmAt\",\n        \"type\": \"uint256\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"uint256\",\n        \"name\": \"newConfirmAt\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"SetConfirmation\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": false,\n        \"internalType\": \"uint256\",\n        \"name\": \"timeout\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"SetOptimisticTimeout\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"uint32\",\n        \"name\": \"homeDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"oldRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"newRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"bytes\",\n        \"name\": \"signature\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"Update\",\n    \"type\": \"event\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"PROCESS_GAS\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"RESERVE_GAS\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"VERSION\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint8\",\n        \"name\": \"\",\n        \"type\": \"uint8\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_root\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"acceptableRoot\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"committedRoot\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"confirmAt\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_oldRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes32[2]\",\n        \"name\": \"_newRoot\",\n        \"type\": \"bytes32[2]\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"_signature\",\n        \"type\": \"bytes\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"_signature2\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"doubleUpdate\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"homeDomainHash\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"_remoteDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"internalType\": \"address\",\n        \"name\": \"_updater\",\n        \"type\": \"address\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_committedRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_optimisticSeconds\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"initialize\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"localDomain\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"\",\n        \"type\": \"uint32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"messages\",\n    \"outputs\": [\n      {\n        \"internalType\": \"enum Replica.MessageStatus\",\n        \"name\": \"\",\n        \"type\": \"uint8\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"optimisticSeconds\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"owner\",\n    \"outputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"\",\n        \"type\": \"address\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"_message\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"process\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"_success\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_leaf\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes32[32]\",\n        \"name\": \"_proof\",\n        \"type\": \"bytes32[32]\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_index\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"prove\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"_message\",\n        \"type\": \"bytes\"\n      },\n      {\n        \"internalType\": \"bytes32[32]\",\n        \"name\": \"_proof\",\n        \"type\": \"bytes32[32]\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_index\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"proveAndProcess\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"remoteDomain\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"\",\n        \"type\": \"uint32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"renounceOwnership\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_root\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_confirmAt\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"setConfirmation\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_optimisticSeconds\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"setOptimisticTimeout\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"_updater\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"setUpdater\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"state\",\n    \"outputs\": [\n      {\n        \"internalType\": \"enum NomadBase.States\",\n        \"name\": \"\",\n        \"type\": \"uint8\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"newOwner\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"transferOwnership\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_oldRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_newRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"_signature\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"update\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"updater\",\n    \"outputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"\",\n        \"type\": \"address\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  }\n]\n") . expect ("invalid abi")
+            serde_json :: from_str ("[\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"_localDomain\",\n        \"type\": \"uint32\"\n      }\n    ],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"constructor\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": false,\n        \"internalType\": \"address\",\n        \"name\": \"oldUpdater\",\n        \"type\": \"address\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"address\",\n        \"name\": \"newUpdater\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"NewUpdater\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"address\",\n        \"name\": \"previousOwner\",\n        \"type\": \"address\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"address\",\n        \"name\": \"newOwner\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"OwnershipTransferred\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"messageHash\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bool\",\n        \"name\": \"success\",\n        \"type\": \"bool\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes\",\n        \"name\": \"returnData\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"Process\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"root\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"uint256\",\n        \"name\": \"previousConfirmAt\",\n        \"type\": \"uint256\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"uint256\",\n        \"name\": \"newConfirmAt\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"SetConfirmation\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": false,\n        \"internalType\": \"uint256\",\n        \"name\": \"timeout\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"SetOptimisticTimeout\",\n    \"type\": \"event\"\n  },\n  {\n    \"anonymous\": false,\n    \"inputs\": [\n      {\n        \"indexed\": true,\n        \"internalType\": \"uint32\",\n        \"name\": \"homeDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"oldRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": true,\n        \"internalType\": \"bytes32\",\n        \"name\": \"newRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"indexed\": false,\n        \"internalType\": \"bytes\",\n        \"name\": \"signature\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"Update\",\n    \"type\": \"event\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"LEGACY_STATUS_NONE\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"LEGACY_STATUS_PROCESSED\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"LEGACY_STATUS_PROVEN\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"VERSION\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint8\",\n        \"name\": \"\",\n        \"type\": \"uint8\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_root\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"acceptableRoot\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"committedRoot\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"confirmAt\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"homeDomainHash\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"_remoteDomain\",\n        \"type\": \"uint32\"\n      },\n      {\n        \"internalType\": \"address\",\n        \"name\": \"_updater\",\n        \"type\": \"address\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_committedRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_optimisticSeconds\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"initialize\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"localDomain\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"\",\n        \"type\": \"uint32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"name\": \"messages\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"\",\n        \"type\": \"bytes32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"optimisticSeconds\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"owner\",\n    \"outputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"\",\n        \"type\": \"address\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"_message\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"process\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"_success\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_leaf\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes32[32]\",\n        \"name\": \"_proof\",\n        \"type\": \"bytes32[32]\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_index\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"prove\",\n    \"outputs\": [\n      {\n        \"internalType\": \"bool\",\n        \"name\": \"\",\n        \"type\": \"bool\"\n      }\n    ],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"_message\",\n        \"type\": \"bytes\"\n      },\n      {\n        \"internalType\": \"bytes32[32]\",\n        \"name\": \"_proof\",\n        \"type\": \"bytes32[32]\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_index\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"proveAndProcess\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"remoteDomain\",\n    \"outputs\": [\n      {\n        \"internalType\": \"uint32\",\n        \"name\": \"\",\n        \"type\": \"uint32\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"renounceOwnership\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_root\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_confirmAt\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"setConfirmation\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"uint256\",\n        \"name\": \"_optimisticSeconds\",\n        \"type\": \"uint256\"\n      }\n    ],\n    \"name\": \"setOptimisticTimeout\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"_updater\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"setUpdater\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"state\",\n    \"outputs\": [\n      {\n        \"internalType\": \"enum NomadBase.States\",\n        \"name\": \"\",\n        \"type\": \"uint8\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"newOwner\",\n        \"type\": \"address\"\n      }\n    ],\n    \"name\": \"transferOwnership\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_oldRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes32\",\n        \"name\": \"_newRoot\",\n        \"type\": \"bytes32\"\n      },\n      {\n        \"internalType\": \"bytes\",\n        \"name\": \"_signature\",\n        \"type\": \"bytes\"\n      }\n    ],\n    \"name\": \"update\",\n    \"outputs\": [],\n    \"stateMutability\": \"nonpayable\",\n    \"type\": \"function\"\n  },\n  {\n    \"inputs\": [],\n    \"name\": \"updater\",\n    \"outputs\": [\n      {\n        \"internalType\": \"address\",\n        \"name\": \"\",\n        \"type\": \"address\"\n      }\n    ],\n    \"stateMutability\": \"view\",\n    \"type\": \"function\"\n  }\n]\n") . expect ("invalid abi")
         });
     pub struct Replica<M>(ethers::contract::Contract<M>);
     impl<M> Clone for Replica<M> {
@@ -49,20 +49,26 @@ mod replica_mod {
         ) -> Self {
             ethers::contract::Contract::new(address.into(), REPLICA_ABI.clone(), client).into()
         }
-        #[doc = "Calls the contract's `PROCESS_GAS` (0xd88beda2) function"]
-        pub fn process_gas(
-            &self,
-        ) -> ethers::contract::builders::ContractCall<M, ethers::core::types::U256> {
+        #[doc = "Calls the contract's `LEGACY_STATUS_NONE` (0x18810b89) function"]
+        pub fn legacy_status_none(&self) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
             self.0
-                .method_hash([216, 139, 237, 162], ())
+                .method_hash([24, 129, 11, 137], ())
                 .expect("method not found (this should never happen)")
         }
-        #[doc = "Calls the contract's `RESERVE_GAS` (0x25e3beda) function"]
-        pub fn reserve_gas(
+        #[doc = "Calls the contract's `LEGACY_STATUS_PROCESSED` (0xb1e3fb8c) function"]
+        pub fn legacy_status_processed(
             &self,
-        ) -> ethers::contract::builders::ContractCall<M, ethers::core::types::U256> {
+        ) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
             self.0
-                .method_hash([37, 227, 190, 218], ())
+                .method_hash([177, 227, 251, 140], ())
+                .expect("method not found (this should never happen)")
+        }
+        #[doc = "Calls the contract's `LEGACY_STATUS_PROVEN` (0x2e7bb32c) function"]
+        pub fn legacy_status_proven(
+            &self,
+        ) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
+            self.0
+                .method_hash([46, 123, 179, 44], ())
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `VERSION` (0xffa1ad74) function"]
@@ -95,21 +101,6 @@ mod replica_mod {
                 .method_hash([113, 191, 183, 184], p0)
                 .expect("method not found (this should never happen)")
         }
-        #[doc = "Calls the contract's `doubleUpdate` (0x19d9d21a) function"]
-        pub fn double_update(
-            &self,
-            old_root: [u8; 32],
-            new_root: [[u8; 32]; 2usize],
-            signature: ethers::core::types::Bytes,
-            signature_2: ethers::core::types::Bytes,
-        ) -> ethers::contract::builders::ContractCall<M, ()> {
-            self.0
-                .method_hash(
-                    [25, 217, 210, 26],
-                    (old_root, new_root, signature, signature_2),
-                )
-                .expect("method not found (this should never happen)")
-        }
         #[doc = "Calls the contract's `homeDomainHash` (0x45630b1a) function"]
         pub fn home_domain_hash(&self) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
             self.0
@@ -138,7 +129,10 @@ mod replica_mod {
                 .expect("method not found (this should never happen)")
         }
         #[doc = "Calls the contract's `messages` (0x2bbd59ca) function"]
-        pub fn messages(&self, p0: [u8; 32]) -> ethers::contract::builders::ContractCall<M, u8> {
+        pub fn messages(
+            &self,
+            p0: [u8; 32],
+        ) -> ethers::contract::builders::ContractCall<M, [u8; 32]> {
             self.0
                 .method_hash([43, 189, 89, 202], p0)
                 .expect("method not found (this should never happen)")
@@ -264,12 +258,6 @@ mod replica_mod {
                 .method_hash([223, 3, 76, 208], ())
                 .expect("method not found (this should never happen)")
         }
-        #[doc = "Gets the contract's `DoubleUpdate` event"]
-        pub fn double_update_filter(
-            &self,
-        ) -> ethers::contract::builders::Event<M, DoubleUpdateFilter> {
-            self.0.event()
-        }
         #[doc = "Gets the contract's `NewUpdater` event"]
         pub fn new_updater_filter(&self) -> ethers::contract::builders::Event<M, NewUpdaterFilter> {
             self.0.event()
@@ -309,25 +297,6 @@ mod replica_mod {
         fn from(contract: ethers::contract::Contract<M>) -> Self {
             Self(contract)
         }
-    }
-    #[derive(
-        Clone,
-        Debug,
-        Default,
-        Eq,
-        PartialEq,
-        ethers :: contract :: EthEvent,
-        ethers :: contract :: EthDisplay,
-    )]
-    #[ethevent(
-        name = "DoubleUpdate",
-        abi = "DoubleUpdate(bytes32,bytes32[2],bytes,bytes)"
-    )]
-    pub struct DoubleUpdateFilter {
-        pub old_root: [u8; 32],
-        pub new_root: [[u8; 32]; 2],
-        pub signature: ethers::core::types::Bytes,
-        pub signature_2: ethers::core::types::Bytes,
     }
     #[derive(
         Clone,
@@ -433,7 +402,6 @@ mod replica_mod {
     }
     #[derive(Debug, Clone, PartialEq, Eq, ethers :: contract :: EthAbiType)]
     pub enum ReplicaEvents {
-        DoubleUpdateFilter(DoubleUpdateFilter),
         NewUpdaterFilter(NewUpdaterFilter),
         OwnershipTransferredFilter(OwnershipTransferredFilter),
         ProcessFilter(ProcessFilter),
@@ -446,9 +414,6 @@ mod replica_mod {
         where
             Self: Sized,
         {
-            if let Ok(decoded) = DoubleUpdateFilter::decode_log(log) {
-                return Ok(ReplicaEvents::DoubleUpdateFilter(decoded));
-            }
             if let Ok(decoded) = NewUpdaterFilter::decode_log(log) {
                 return Ok(ReplicaEvents::NewUpdaterFilter(decoded));
             }
@@ -473,7 +438,6 @@ mod replica_mod {
     impl ::std::fmt::Display for ReplicaEvents {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match self {
-                ReplicaEvents::DoubleUpdateFilter(element) => element.fmt(f),
                 ReplicaEvents::NewUpdaterFilter(element) => element.fmt(f),
                 ReplicaEvents::OwnershipTransferredFilter(element) => element.fmt(f),
                 ReplicaEvents::ProcessFilter(element) => element.fmt(f),
@@ -483,7 +447,7 @@ mod replica_mod {
             }
         }
     }
-    #[doc = "Container type for all input parameters for the `PROCESS_GAS`function with signature `PROCESS_GAS()` and selector `[216, 139, 237, 162]`"]
+    #[doc = "Container type for all input parameters for the `LEGACY_STATUS_NONE`function with signature `LEGACY_STATUS_NONE()` and selector `[24, 129, 11, 137]`"]
     #[derive(
         Clone,
         Debug,
@@ -493,9 +457,9 @@ mod replica_mod {
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
     )]
-    #[ethcall(name = "PROCESS_GAS", abi = "PROCESS_GAS()")]
-    pub struct ProcessGasCall;
-    #[doc = "Container type for all input parameters for the `RESERVE_GAS`function with signature `RESERVE_GAS()` and selector `[37, 227, 190, 218]`"]
+    #[ethcall(name = "LEGACY_STATUS_NONE", abi = "LEGACY_STATUS_NONE()")]
+    pub struct LegacyStatusNoneCall;
+    #[doc = "Container type for all input parameters for the `LEGACY_STATUS_PROCESSED`function with signature `LEGACY_STATUS_PROCESSED()` and selector `[177, 227, 251, 140]`"]
     #[derive(
         Clone,
         Debug,
@@ -505,8 +469,20 @@ mod replica_mod {
         ethers :: contract :: EthCall,
         ethers :: contract :: EthDisplay,
     )]
-    #[ethcall(name = "RESERVE_GAS", abi = "RESERVE_GAS()")]
-    pub struct ReserveGasCall;
+    #[ethcall(name = "LEGACY_STATUS_PROCESSED", abi = "LEGACY_STATUS_PROCESSED()")]
+    pub struct LegacyStatusProcessedCall;
+    #[doc = "Container type for all input parameters for the `LEGACY_STATUS_PROVEN`function with signature `LEGACY_STATUS_PROVEN()` and selector `[46, 123, 179, 44]`"]
+    #[derive(
+        Clone,
+        Debug,
+        Default,
+        Eq,
+        PartialEq,
+        ethers :: contract :: EthCall,
+        ethers :: contract :: EthDisplay,
+    )]
+    #[ethcall(name = "LEGACY_STATUS_PROVEN", abi = "LEGACY_STATUS_PROVEN()")]
+    pub struct LegacyStatusProvenCall;
     #[doc = "Container type for all input parameters for the `VERSION`function with signature `VERSION()` and selector `[255, 161, 173, 116]`"]
     #[derive(
         Clone,
@@ -557,26 +533,6 @@ mod replica_mod {
     )]
     #[ethcall(name = "confirmAt", abi = "confirmAt(bytes32)")]
     pub struct ConfirmAtCall(pub [u8; 32]);
-    #[doc = "Container type for all input parameters for the `doubleUpdate`function with signature `doubleUpdate(bytes32,bytes32[2],bytes,bytes)` and selector `[25, 217, 210, 26]`"]
-    #[derive(
-        Clone,
-        Debug,
-        Default,
-        Eq,
-        PartialEq,
-        ethers :: contract :: EthCall,
-        ethers :: contract :: EthDisplay,
-    )]
-    #[ethcall(
-        name = "doubleUpdate",
-        abi = "doubleUpdate(bytes32,bytes32[2],bytes,bytes)"
-    )]
-    pub struct DoubleUpdateCall {
-        pub old_root: [u8; 32],
-        pub new_root: [[u8; 32]; 2usize],
-        pub signature: ethers::core::types::Bytes,
-        pub signature_2: ethers::core::types::Bytes,
-    }
     #[doc = "Container type for all input parameters for the `homeDomainHash`function with signature `homeDomainHash()` and selector `[69, 99, 11, 26]`"]
     #[derive(
         Clone,
@@ -829,13 +785,13 @@ mod replica_mod {
     pub struct UpdaterCall;
     #[derive(Debug, Clone, PartialEq, Eq, ethers :: contract :: EthAbiType)]
     pub enum ReplicaCalls {
-        ProcessGas(ProcessGasCall),
-        ReserveGas(ReserveGasCall),
+        LegacyStatusNone(LegacyStatusNoneCall),
+        LegacyStatusProcessed(LegacyStatusProcessedCall),
+        LegacyStatusProven(LegacyStatusProvenCall),
         Version(VersionCall),
         AcceptableRoot(AcceptableRootCall),
         CommittedRoot(CommittedRootCall),
         ConfirmAt(ConfirmAtCall),
-        DoubleUpdate(DoubleUpdateCall),
         HomeDomainHash(HomeDomainHashCall),
         Initialize(InitializeCall),
         LocalDomain(LocalDomainCall),
@@ -858,14 +814,19 @@ mod replica_mod {
     impl ethers::core::abi::AbiDecode for ReplicaCalls {
         fn decode(data: impl AsRef<[u8]>) -> Result<Self, ethers::core::abi::AbiError> {
             if let Ok(decoded) =
-                <ProcessGasCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+                <LegacyStatusNoneCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
             {
-                return Ok(ReplicaCalls::ProcessGas(decoded));
+                return Ok(ReplicaCalls::LegacyStatusNone(decoded));
             }
             if let Ok(decoded) =
-                <ReserveGasCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+                <LegacyStatusProcessedCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
             {
-                return Ok(ReplicaCalls::ReserveGas(decoded));
+                return Ok(ReplicaCalls::LegacyStatusProcessed(decoded));
+            }
+            if let Ok(decoded) =
+                <LegacyStatusProvenCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
+            {
+                return Ok(ReplicaCalls::LegacyStatusProven(decoded));
             }
             if let Ok(decoded) =
                 <VersionCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
@@ -886,11 +847,6 @@ mod replica_mod {
                 <ConfirmAtCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
             {
                 return Ok(ReplicaCalls::ConfirmAt(decoded));
-            }
-            if let Ok(decoded) =
-                <DoubleUpdateCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
-            {
-                return Ok(ReplicaCalls::DoubleUpdate(decoded));
             }
             if let Ok(decoded) =
                 <HomeDomainHashCall as ethers::core::abi::AbiDecode>::decode(data.as_ref())
@@ -984,13 +940,13 @@ mod replica_mod {
     impl ethers::core::abi::AbiEncode for ReplicaCalls {
         fn encode(self) -> Vec<u8> {
             match self {
-                ReplicaCalls::ProcessGas(element) => element.encode(),
-                ReplicaCalls::ReserveGas(element) => element.encode(),
+                ReplicaCalls::LegacyStatusNone(element) => element.encode(),
+                ReplicaCalls::LegacyStatusProcessed(element) => element.encode(),
+                ReplicaCalls::LegacyStatusProven(element) => element.encode(),
                 ReplicaCalls::Version(element) => element.encode(),
                 ReplicaCalls::AcceptableRoot(element) => element.encode(),
                 ReplicaCalls::CommittedRoot(element) => element.encode(),
                 ReplicaCalls::ConfirmAt(element) => element.encode(),
-                ReplicaCalls::DoubleUpdate(element) => element.encode(),
                 ReplicaCalls::HomeDomainHash(element) => element.encode(),
                 ReplicaCalls::Initialize(element) => element.encode(),
                 ReplicaCalls::LocalDomain(element) => element.encode(),
@@ -1015,13 +971,13 @@ mod replica_mod {
     impl ::std::fmt::Display for ReplicaCalls {
         fn fmt(&self, f: &mut ::std::fmt::Formatter<'_>) -> ::std::fmt::Result {
             match self {
-                ReplicaCalls::ProcessGas(element) => element.fmt(f),
-                ReplicaCalls::ReserveGas(element) => element.fmt(f),
+                ReplicaCalls::LegacyStatusNone(element) => element.fmt(f),
+                ReplicaCalls::LegacyStatusProcessed(element) => element.fmt(f),
+                ReplicaCalls::LegacyStatusProven(element) => element.fmt(f),
                 ReplicaCalls::Version(element) => element.fmt(f),
                 ReplicaCalls::AcceptableRoot(element) => element.fmt(f),
                 ReplicaCalls::CommittedRoot(element) => element.fmt(f),
                 ReplicaCalls::ConfirmAt(element) => element.fmt(f),
-                ReplicaCalls::DoubleUpdate(element) => element.fmt(f),
                 ReplicaCalls::HomeDomainHash(element) => element.fmt(f),
                 ReplicaCalls::Initialize(element) => element.fmt(f),
                 ReplicaCalls::LocalDomain(element) => element.fmt(f),
@@ -1043,14 +999,19 @@ mod replica_mod {
             }
         }
     }
-    impl ::std::convert::From<ProcessGasCall> for ReplicaCalls {
-        fn from(var: ProcessGasCall) -> Self {
-            ReplicaCalls::ProcessGas(var)
+    impl ::std::convert::From<LegacyStatusNoneCall> for ReplicaCalls {
+        fn from(var: LegacyStatusNoneCall) -> Self {
+            ReplicaCalls::LegacyStatusNone(var)
         }
     }
-    impl ::std::convert::From<ReserveGasCall> for ReplicaCalls {
-        fn from(var: ReserveGasCall) -> Self {
-            ReplicaCalls::ReserveGas(var)
+    impl ::std::convert::From<LegacyStatusProcessedCall> for ReplicaCalls {
+        fn from(var: LegacyStatusProcessedCall) -> Self {
+            ReplicaCalls::LegacyStatusProcessed(var)
+        }
+    }
+    impl ::std::convert::From<LegacyStatusProvenCall> for ReplicaCalls {
+        fn from(var: LegacyStatusProvenCall) -> Self {
+            ReplicaCalls::LegacyStatusProven(var)
         }
     }
     impl ::std::convert::From<VersionCall> for ReplicaCalls {
@@ -1071,11 +1032,6 @@ mod replica_mod {
     impl ::std::convert::From<ConfirmAtCall> for ReplicaCalls {
         fn from(var: ConfirmAtCall) -> Self {
             ReplicaCalls::ConfirmAt(var)
-        }
-    }
-    impl ::std::convert::From<DoubleUpdateCall> for ReplicaCalls {
-        fn from(var: DoubleUpdateCall) -> Self {
-            ReplicaCalls::DoubleUpdate(var)
         }
     }
     impl ::std::convert::From<HomeDomainHashCall> for ReplicaCalls {

--- a/nomad-core/src/traits/replica.rs
+++ b/nomad-core/src/traits/replica.rs
@@ -9,14 +9,31 @@ use crate::{
 };
 
 /// The status of a message in the replica
-#[repr(u8)]
 pub enum MessageStatus {
     /// Message is unknown
-    None = 0,
+    None,
     /// Message has been proven but not processed
-    Proven = 1,
+    Proven(H256),
     /// Message has been processed
-    Processed = 2,
+    Processed,
+}
+impl From<H256> for MessageStatus {
+    fn from(status: H256) -> Self {
+        if status.is_zero() {
+            return MessageStatus::None;
+        }
+        if status == H256::from_low_u64_be(2) {
+            return MessageStatus::Processed;
+        }
+        MessageStatus::Proven(status)
+    }
+}
+
+impl From<[u8; 32]> for MessageStatus {
+    fn from(status: [u8; 32]) -> Self {
+        let status: H256 = status.into();
+        status.into()
+    }
 }
 
 /// Interface for on-chain replicas

--- a/tools/nomad-cli/src/subcommands/prove.rs
+++ b/tools/nomad-cli/src/subcommands/prove.rs
@@ -78,7 +78,7 @@ impl ProveCommand {
         let status = replica.message_status(message.to_leaf()).await?;
         let outcome = match status {
             MessageStatus::None => replica.prove_and_process(&message, &proof).await?,
-            MessageStatus::Proven => replica.process(&message).await?,
+            MessageStatus::Proven(_) => replica.process(&message).await?,
             _ => {
                 println!("Message already processed.");
                 return Ok(());


### PR DESCRIPTION

## Motivation

We failed to consider interaction of backwards compatible contract type changes with the agents' rust type system

## Solution

Update abi bindings with new message status system
disable double-updates by returning an empty txoutcome

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
