### PR TITLE
feat(configuration): optionally disable build

### DIFF
--- a/configuration/build.rs
+++ b/configuration/build.rs
@@ -1,3 +1,7 @@
+//! Fetches latest configs from `CONFIG_BASE_URI` and stores them in
+//! `configuration/configs`. To disable this feature pre-build or pre-test, set
+//! the environment variable `BUILD_DISABLED`.
+
 use std::{fs, io::Write, path::PathBuf};
 
 const DEFINITIONS: &str = include_str!(concat!(env!("CARGO_MANIFEST_DIR"), "/data/definitions.ts"));
@@ -88,29 +92,33 @@ const _: &'static str = r#""###
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    println!(
-        "cargo:rerun-if-changed={}",
-        concat!(env!("CARGO_MANIFEST_DIR"), "/data/definitions.ts")
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        concat!(env!("CARGO_MANIFEST_DIR"), "/data/types.rs")
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        concat!(env!("CARGO_MANIFEST_DIR"), "/configs/production.json")
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        concat!(env!("CARGO_MANIFEST_DIR"), "/configs/development.json")
-    );
-    println!(
-        "cargo:rerun-if-changed={}",
-        concat!(env!("CARGO_MANIFEST_DIR"), "/configs/staging.json")
-    );
+    if std::env::var("BUILD_DISABLED").is_ok() {
+        println!("Skipping build script");
+    } else {
+        println!(
+            "cargo:rerun-if-changed={}",
+            concat!(env!("CARGO_MANIFEST_DIR"), "/data/definitions.ts")
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            concat!(env!("CARGO_MANIFEST_DIR"), "/data/types.rs")
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            concat!(env!("CARGO_MANIFEST_DIR"), "/configs/production.json")
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            concat!(env!("CARGO_MANIFEST_DIR"), "/configs/development.json")
+        );
+        println!(
+            "cargo:rerun-if-changed={}",
+            concat!(env!("CARGO_MANIFEST_DIR"), "/configs/staging.json")
+        );
 
-    gen_wasm_bindgen()?;
-    get_configs().await?;
+        gen_wasm_bindgen()?;
+        get_configs().await?;
+    }
 
     Ok(())
 }

--- a/configuration/build.rs
+++ b/configuration/build.rs
@@ -92,31 +92,30 @@ const _: &'static str = r#""###
 
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
-    if std::env::var("BUILD_DISABLED").is_ok() {
-        println!("Skipping build script");
-    } else {
-        println!(
-            "cargo:rerun-if-changed={}",
-            concat!(env!("CARGO_MANIFEST_DIR"), "/data/definitions.ts")
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            concat!(env!("CARGO_MANIFEST_DIR"), "/data/types.rs")
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            concat!(env!("CARGO_MANIFEST_DIR"), "/configs/production.json")
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            concat!(env!("CARGO_MANIFEST_DIR"), "/configs/development.json")
-        );
-        println!(
-            "cargo:rerun-if-changed={}",
-            concat!(env!("CARGO_MANIFEST_DIR"), "/configs/staging.json")
-        );
+    println!(
+        "cargo:rerun-if-changed={}",
+        concat!(env!("CARGO_MANIFEST_DIR"), "/data/definitions.ts")
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        concat!(env!("CARGO_MANIFEST_DIR"), "/data/types.rs")
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        concat!(env!("CARGO_MANIFEST_DIR"), "/configs/production.json")
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        concat!(env!("CARGO_MANIFEST_DIR"), "/configs/development.json")
+    );
+    println!(
+        "cargo:rerun-if-changed={}",
+        concat!(env!("CARGO_MANIFEST_DIR"), "/configs/staging.json")
+    );
+    gen_wasm_bindgen()?;
 
-        gen_wasm_bindgen()?;
+    // don't re-fetch configs if programmer disables build
+    if std::env::var("BUILD_DISABLED").is_err() {
         get_configs().await?;
     }
 


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

For now, we don't have `config` repo CI. Want to manual validate by pasting config from `config` into rust repo and checking tests.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Optional ability to disable fetching configs in build so that we don't always load gh pages configs on `cargo test`. We can now disable build, paste in new config we want to validate, and run test with `BUILD_DISABLED=true cargo test`

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
