### PR TITLE
refactor: remove deprecated deploy configuration keys

### DIFF
--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- refactor: remove protocol and bridge deploy-time gas value configuration
 - feature: pull config files from github pages instead of local versions
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides
@@ -17,7 +18,8 @@
 ### v0.1.0-rc.24
 
 - remove `FromEnv` trait and make env loading conf-struct-specific
-- add handling for default keys `TRANSACTIONSIGNERS_DEFAULT_{KEY,ID,REGION}` and `RPCS_DEFAULT_RPCSTYLE`
+- add handling for default keys `TRANSACTIONSIGNERS_DEFAULT_{KEY,ID,REGION}`
+  and `RPCS_DEFAULT_RPCSTYLE`
 - add tests for new default config keys
 - make aws key region non-functional (region should be read from env)
 - set goerli as the new hub for development / staging in the gui
@@ -33,7 +35,8 @@
 
 ### v0.1.0-rc.21
 
-- validation of configured secrets takes in list of remote networks given that we can now specify remote networks of interest
+- validation of configured secrets takes in list of remote networks given that
+  we can now specify remote networks of interest
 - adds 3rd network to test.json to test partial specification of remotes
 - add evmostestnet staging deploys
 
@@ -108,7 +111,8 @@
 ### v0.1.0-rc.6
 
 - refactor: move common types (e.g. NomadIdentifier) into rust/nomad-types
-- refactor: replcace BaseAgentConfig with agent-specific public config blocks instantiated with interval and enabled there by default
+- refactor: replcace BaseAgentConfig with agent-specific public config blocks
+  instantiated with interval and enabled there by default
 - fix: uint deser_nomad_number expanded beyond just u64
 
 ### v0.1.0-rc.5

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+- feature: add more explicit Processor Config TS declaration
+- refactor: make Processor config keys optional, and prevent trivial ser.
+- fix: update TS AgentConfig to match rust
 - refactor: remove protocol and bridge deploy-time gas value configuration
 - feature: pull config files from github pages instead of local versions
 - add environment variable overrides for agent configuration

--- a/configuration/configs/test.json
+++ b/configuration/configs/test.json
@@ -28,9 +28,6 @@
         },
         "configuration": {
           "optimisticSeconds": 1800,
-          "processGas": 850000,
-          "reserveGas": 25000,
-          "maximumGas": 1000000,
           "governance": {
             "recoveryManager": "0xda2f881f7f4e9d2b9559f97c7670472a85c1986a",
             "recoveryTimelock": 86400
@@ -39,9 +36,7 @@
           "watchers": ["0x9782A3C8128f5D1BD3C9655d03181ba5b420883E"]
         },
         "bridgeConfiguration": {
-          "weth": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-          "mintGas": 200000,
-          "deployGas": 850000
+          "weth": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
         }
       },
       "moonbeam": {
@@ -59,9 +54,6 @@
         },
         "configuration": {
           "optimisticSeconds": 1800,
-          "processGas": 850000,
-          "reserveGas": 25000,
-          "maximumGas": 1000000,
           "governance": {
             "governor": {
               "id": "0x93277b8f5939975b9e6694d5fd2837143afbf68a",
@@ -74,9 +66,7 @@
           "watchers": ["0x297BBC2F2EAAEB17Ee53F514020bC8173F0570dC"]
         },
         "bridgeConfiguration": {
-          "weth": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2",
-          "mintGas": 200000,
-          "deployGas": 850000
+          "weth": "0xc02aaa39b223fe8d0a0e5c4f27ead9083c756cc2"
         }
       },
       "evmos": {
@@ -85,9 +75,6 @@
         "connections": ["ethereum", "moonbeam"],
         "configuration": {
           "optimisticSeconds": 1800,
-          "processGas": 850000,
-          "reserveGas": 25000,
-          "maximumGas": 1000000,
           "updater": "0xc8e344d4698b6462187c88b9bb58f26ca3b5ed31",
           "watchers": ["0x9e8e7eb5886a9c77e955fd5d717581556eb7f98d"],
           "governance": {
@@ -116,9 +103,7 @@
               "symbol": "USDC",
               "decimals": 6
             }
-          ],
-          "mintGas": 200000,
-          "deployGas": 850000
+          ]
         }
       }
     }

--- a/configuration/data/definitions.ts
+++ b/configuration/data/definitions.ts
@@ -23,6 +23,13 @@ export interface BaseAgentConfig {
   interval: number | string;
 }
 
+export type ProcessorConfig = BaseAgentConfig & {
+  allowed?: string[];
+  denied?: string[];
+  subsidizedRemotes?: string[];
+  s3?: S3Config;
+};
+
 export interface AgentConfig {
   rpcStyle: string;
   db: string;
@@ -30,7 +37,7 @@ export interface AgentConfig {
   logging: LogConfig;
   updater: BaseAgentConfig;
   relayer: BaseAgentConfig;
-  processor: BaseAgentConfig;
+  processor: ProcessorConfig;
   watcher: BaseAgentConfig;
   kathy: BaseAgentConfig;
 }

--- a/configuration/data/definitions.ts
+++ b/configuration/data/definitions.ts
@@ -25,8 +25,8 @@ export interface BaseAgentConfig {
 
 export interface AgentConfig {
   rpcStyle: string;
-  timelag: number | string;
   db: string;
+  metrics: number;
   logging: LogConfig;
   updater: BaseAgentConfig;
   relayer: BaseAgentConfig;

--- a/configuration/data/definitions.ts
+++ b/configuration/data/definitions.ts
@@ -81,9 +81,6 @@ export interface Governance {
 
 export interface ContractConfig {
   optimisticSeconds: number | string;
-  processGas: number | string;
-  reserveGas: number | string;
-  maximumGas: number | string;
   governance: Governance;
   updater: NomadIdentifier;
   watchers: Array<NomadIdentifier>;
@@ -109,8 +106,6 @@ export interface CustomTokenSpecifier {
 export interface BridgeConfiguration {
   weth?: NomadIdentifier;
   customs?: Array<CustomTokenSpecifier>;
-  mintGas: number | string;
-  deployGas: number | string;
 }
 
 export interface Domain {

--- a/configuration/src/agent/processor.rs
+++ b/configuration/src/agent/processor.rs
@@ -6,10 +6,13 @@ use std::collections::HashSet;
 
 decl_config!(Processor {
     /// Allow list
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     allowed: Option<HashSet<H256>>,
     /// Deny list
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     denied: Option<HashSet<H256>>,
     /// Remote chains to subsidize processing on
+    #[serde(default, skip_serializing_if = "HashSet::is_empty")]
     subsidized_remotes: HashSet<String>,
     /// Whether to upload proofs to s3
     #[serde(default, skip_serializing_if = "Option::is_none")]

--- a/configuration/src/bridge.rs
+++ b/configuration/src/bridge.rs
@@ -89,12 +89,4 @@ pub struct BridgeConfiguration {
     /// Custom token deployment specifiers
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub customs: Option<HashSet<CustomTokenSpecifier>>,
-    /// Amount of gas required to execute a `Transfer` message that DOST NOT
-    /// cause contract deployment
-    #[serde(default, deserialize_with = "deser_nomad_u64")]
-    pub mint_gas: u64,
-    /// Amount of gas required to execute a `Transfer` message that DOES cause
-    /// contract deployment
-    #[serde(default, deserialize_with = "deser_nomad_u64")]
-    pub deploy_gas: u64,
 }

--- a/configuration/src/network.rs
+++ b/configuration/src/network.rs
@@ -26,15 +26,6 @@ pub struct ContractConfig {
     /// Optimsitic seconds for replicas to wait
     #[serde(deserialize_with = "deser_nomad_u64")]
     pub optimistic_seconds: u64,
-    /// Default process gas
-    #[serde(deserialize_with = "deser_nomad_u64")]
-    pub process_gas: u64,
-    /// Reserve gas
-    #[serde(deserialize_with = "deser_nomad_u64")]
-    pub reserve_gas: u64,
-    /// Maximum preflight gas
-    #[serde(deserialize_with = "deser_nomad_u64")]
-    pub maximum_gas: u64,
     /// List of updaters for this network
     pub updater: NomadIdentifier,
     /// List of watchers for this network

--- a/configuration/src/wasm/types.rs
+++ b/configuration/src/wasm/types.rs
@@ -29,10 +29,17 @@ export interface BaseAgentConfig {
   interval: number | string;
 }
 
+export type ProcessorConfig = BaseAgentConfig & {
+  allowed?: string[];
+  denied?: string[];
+  subsidizedRemotes: string[];
+  s3?: S3Config;
+};
+
 export interface AgentConfig {
   rpcStyle: string;
-  timelag: number | string;
   db: string;
+  metrics: number;
   logging: LogConfig;
   updater: BaseAgentConfig;
   relayer: BaseAgentConfig;

--- a/configuration/src/wasm/types.rs
+++ b/configuration/src/wasm/types.rs
@@ -87,9 +87,6 @@ export interface Governance {
 
 export interface ContractConfig {
   optimisticSeconds: number | string;
-  processGas: number | string;
-  reserveGas: number | string;
-  maximumGas: number | string;
   governance: Governance;
   updater: NomadIdentifier;
   watchers: Array<NomadIdentifier>;
@@ -115,8 +112,6 @@ export interface CustomTokenSpecifier {
 export interface BridgeConfiguration {
   weth?: NomadIdentifier;
   customs?: Array<CustomTokenSpecifier>;
-  mintGas: number | string;
-  deployGas: number | string;
 }
 
 export interface Domain {

--- a/configuration/src/wasm/types.rs
+++ b/configuration/src/wasm/types.rs
@@ -32,7 +32,7 @@ export interface BaseAgentConfig {
 export type ProcessorConfig = BaseAgentConfig & {
   allowed?: string[];
   denied?: string[];
-  subsidizedRemotes: string[];
+  subsidizedRemotes?: string[];
   s3?: S3Config;
 };
 
@@ -43,7 +43,7 @@ export interface AgentConfig {
   logging: LogConfig;
   updater: BaseAgentConfig;
   relayer: BaseAgentConfig;
-  processor: BaseAgentConfig;
+  processor: ProcessorConfig;
   watcher: BaseAgentConfig;
   kathy: BaseAgentConfig;
 }

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - add home and remote labels to contract sync metrics for event differentiation
 - add `CONFIG_URL` check to `decl_settings` to optionally fetch config from a remote url
+- prometheus metrics accepts port by env var
 - bug: add checks for empty replica name arrays in `NomadAgent::run_many` and
   `NomadAgent::run_all`
 - add `previously_attempted` to the DB schema

--- a/nomad-base/src/metrics.rs
+++ b/nomad-base/src/metrics.rs
@@ -241,9 +241,8 @@ impl CoreMetrics {
         use warp::Filter;
 
         // Default to port 9090
-        let port = self
-            .listen_port
-            .or_else(|| u16_from_env("METRICS_PORT"))
+        let port = u16_from_env("METRICS_PORT")
+            .or(self.listen_port)
             .unwrap_or(9090);
         tracing::info!(
             port,

--- a/nomad-base/src/metrics.rs
+++ b/nomad-base/src/metrics.rs
@@ -7,6 +7,10 @@ use prometheus::{
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 
+fn u16_from_env(s: impl AsRef<str>) -> Option<u16> {
+    std::env::var(s.as_ref()).ok().and_then(|i| i.parse().ok())
+}
+
 #[derive(Debug)]
 /// Metrics for a particular domain
 pub struct CoreMetrics {
@@ -237,7 +241,10 @@ impl CoreMetrics {
         use warp::Filter;
 
         // Default to port 9090
-        let port = self.listen_port.unwrap_or(9090);
+        let port = self
+            .listen_port
+            .or_else(|| u16_from_env("METRICS_PORT"))
+            .unwrap_or(9090);
         tracing::info!(
             port,
             "starting prometheus server on 0.0.0.0:{port}",


### PR DESCRIPTION
## Motivation

As of 1.1.0, the protcol is no longer gas-aware. We have removed these keys from the deployment process, and should remove them from the config types

## Solution

- Remove protocol gas configuration keys from the configuration types
- Remove them from wasm typedefs as well

## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package


## followup

- delete these keys from env configs in main config repo