### PR TITLE
fix(metrics): contract sync metrics take home and replica labels

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -29,3 +29,4 @@ the code change.
 - [ ] Added Tests
 - [ ] Updated Documentation
 - [ ] Updated CHANGELOG.md for the appropriate package
+- [ ] Ran PR in local/dev/staging

--- a/agents/relayer/src/relayer.rs
+++ b/agents/relayer/src/relayer.rs
@@ -232,6 +232,7 @@ mod test {
             let home_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
                 "home_1".to_owned(),
+                "replica_1".to_owned(),
                 home_db.clone(),
                 home_indexer.clone(),
                 IndexSettings::default(),
@@ -273,6 +274,7 @@ mod test {
             let replica_db = NomadDB::new("replica_1", db.clone());
             let replica_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
+                "home_1".to_owned(),
                 "replica_1".to_owned(),
                 replica_db.clone(),
                 replica_indexer.clone(),

--- a/agents/watcher/src/watcher.rs
+++ b/agents/watcher/src/watcher.rs
@@ -741,6 +741,7 @@ mod test {
             let home_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
                 "home_1".to_owned(),
+                "replica_1".to_owned(),
                 nomad_db.clone(),
                 home_indexer.clone(),
                 IndexSettings::default(),
@@ -836,6 +837,7 @@ mod test {
             let home_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
                 "home_1".to_owned(),
+                "replica_1".to_owned(),
                 nomad_db.clone(),
                 home_indexer.clone(),
                 IndexSettings::default(),
@@ -938,6 +940,7 @@ mod test {
             let home_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
                 "home_1".to_owned(),
+                "replica_1".to_owned(),
                 nomad_db.clone(),
                 home_indexer,
                 IndexSettings::default(),
@@ -1147,6 +1150,7 @@ mod test {
             let home_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
                 "home_1".to_owned(),
+                "replica_1".to_owned(),
                 home_db.clone(),
                 home_indexer.clone(),
                 IndexSettings::default(),
@@ -1157,6 +1161,7 @@ mod test {
             let replica_1_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
                 "replica_1".to_owned(),
+                "replica_1".to_owned(),
                 replica_1_db.clone(),
                 replica_indexer.clone(),
                 IndexSettings::default(),
@@ -1166,6 +1171,7 @@ mod test {
             );
             let replica_2_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
+                "home_2".to_owned(),
                 "replica_2".to_owned(),
                 replica_2_db.clone(),
                 replica_indexer.clone(),
@@ -1340,6 +1346,7 @@ mod test {
             let home_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
                 "home_1".to_owned(),
+                "replica_1".to_owned(),
                 home_db.clone(),
                 home_indexer.clone(),
                 IndexSettings::default(),
@@ -1349,6 +1356,7 @@ mod test {
             );
             let replica_1_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
+                "home_1".to_owned(),
                 "replica_1".to_owned(),
                 replica_1_db.clone(),
                 replica_indexer.clone(),
@@ -1359,6 +1367,7 @@ mod test {
             );
             let replica_2_sync = ContractSync::new(
                 AGENT_NAME.to_owned(),
+                "home_2".to_owned(),
                 "replica_2".to_owned(),
                 replica_2_db.clone(),
                 replica_indexer.clone(),

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add home and remote labels to contract sync metrics for event differentiation
 - add `CONFIG_URL` check to `decl_settings` to optionally fetch config from a remote url
 - bug: add checks for empty replica name arrays in `NomadAgent::run_many` and
   `NomadAgent::run_all`

--- a/nomad-base/src/contract_sync/metrics.rs
+++ b/nomad-base/src/contract_sync/metrics.rs
@@ -21,14 +21,14 @@ impl ContractSyncMetrics {
             .new_int_gauge_vec(
                 "contract_sync_block_height",
                 "Height of a recently observed block",
-                &["data_type", "home", "remote", "agent"],
+                &["data_type", "home", "replica", "agent"],
             )
             .expect("failed to register block_height metric");
         let store_event_latency = metrics
             .new_histogram(
                 "contract_sync_store_event_latency",
                 "Latency between event emit and event store in db.",
-                &["data_type", "home", "remote", "agent"],
+                &["data_type", "home", "replica", "agent"],
                 &[
                     0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 120.0, 140.0,
                     160.0, 180.0, 200.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0, 1000.0, 2000.0,
@@ -40,7 +40,7 @@ impl ContractSyncMetrics {
             .new_int_gauge_vec(
                 "contract_sync_stored_events",
                 "Number of events stored into db",
-                &["data_type", "home", "remote", "agent"],
+                &["data_type", "home", "replica", "agent"],
             )
             .expect("failed to register stored_events metric");
 

--- a/nomad-base/src/contract_sync/metrics.rs
+++ b/nomad-base/src/contract_sync/metrics.rs
@@ -12,9 +12,6 @@ pub struct ContractSyncMetrics {
     pub store_event_latency: HistogramVec,
     /// Events stored into DB (label values differentiate updates vs. messages)
     pub stored_events: IntGaugeVec,
-    /// Unique occasions when agent missed an event (label values
-    /// differentiate updates vs. messages)
-    pub missed_events: IntGaugeVec,
 }
 
 impl ContractSyncMetrics {
@@ -24,14 +21,14 @@ impl ContractSyncMetrics {
             .new_int_gauge_vec(
                 "contract_sync_block_height",
                 "Height of a recently observed block",
-                &["data_type", "contract_name", "agent"],
+                &["data_type", "home", "remote", "agent"],
             )
             .expect("failed to register block_height metric");
         let store_event_latency = metrics
             .new_histogram(
                 "contract_sync_store_event_latency",
                 "Latency between event emit and event store in db.",
-                &["data_type", "contract_name", "agent"],
+                &["data_type", "home", "remote", "agent"],
                 &[
                     0.0, 10.0, 20.0, 30.0, 40.0, 50.0, 60.0, 70.0, 80.0, 90.0, 100.0, 120.0, 140.0,
                     160.0, 180.0, 200.0, 250.0, 300.0, 350.0, 400.0, 450.0, 500.0, 1000.0, 2000.0,
@@ -43,23 +40,14 @@ impl ContractSyncMetrics {
             .new_int_gauge_vec(
                 "contract_sync_stored_events",
                 "Number of events stored into db",
-                &["data_type", "contract_name", "agent"],
+                &["data_type", "home", "remote", "agent"],
             )
             .expect("failed to register stored_events metric");
-
-        let missed_events = metrics
-            .new_int_gauge_vec(
-                "contract_sync_missed_events",
-                "Number of unique occasions when agent missed an event",
-                &["data_type", "contract_name", "agent"],
-            )
-            .expect("failed to register missed_events metric");
 
         ContractSyncMetrics {
             indexed_height,
             store_event_latency,
             stored_events,
-            missed_events,
         }
     }
 }

--- a/nomad-base/src/contract_sync/mod.rs
+++ b/nomad-base/src/contract_sync/mod.rs
@@ -28,7 +28,8 @@ const MESSAGES_LABEL: &str = "messages";
 #[derive(Debug, Clone)]
 pub struct ContractSync<I> {
     agent_name: String,
-    contract_name: String,
+    home: String,
+    remote: String,
     db: NomadDB,
     indexer: Arc<I>,
     index_settings: IndexSettings,
@@ -51,7 +52,8 @@ impl<I> ContractSync<I> {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         agent_name: String,
-        contract_name: String,
+        home: String,
+        remote: String,
         db: NomadDB,
         indexer: Arc<I>,
         index_settings: IndexSettings,
@@ -61,7 +63,8 @@ impl<I> ContractSync<I> {
     ) -> Self {
         Self {
             agent_name,
-            contract_name,
+            home,
+            remote,
             db,
             indexer,
             index_settings,
@@ -93,18 +96,20 @@ where
         let indexer = self.indexer.clone();
         let indexed_height = self.metrics.indexed_height.with_label_values(&[
             UPDATES_LABEL,
-            &self.contract_name,
+            &self.home,
+            &self.remote,
             &self.agent_name,
         ]);
         let store_update_latency = self
             .metrics
             .store_event_latency
             .clone()
-            .with_label_values(&[UPDATES_LABEL, &self.contract_name, &self.agent_name]);
+            .with_label_values(&[UPDATES_LABEL, &self.home, &self.remote, &self.agent_name]);
 
         let stored_updates = self.metrics.stored_events.with_label_values(&[
             UPDATES_LABEL,
-            &self.contract_name,
+            &self.home,
+            &self.remote,
             &self.agent_name,
         ]);
 
@@ -247,13 +252,15 @@ where
         let indexer = self.indexer.clone();
         let indexed_height = self.metrics.indexed_height.with_label_values(&[
             MESSAGES_LABEL,
-            &self.contract_name,
+            &self.home,
+            &self.remote,
             &self.agent_name,
         ]);
 
         let stored_messages = self.metrics.stored_events.with_label_values(&[
             MESSAGES_LABEL,
-            &self.contract_name,
+            &self.home,
+            &self.remote,
             &self.agent_name,
         ]);
 
@@ -535,6 +542,7 @@ mod test {
             let contract_sync = ContractSync::new(
                 "agent".to_owned(),
                 "home_1".to_owned(),
+                "replica_1".to_owned(),
                 nomad_db.clone(),
                 indexer.clone(),
                 index_settings,

--- a/nomad-base/src/contract_sync/mod.rs
+++ b/nomad-base/src/contract_sync/mod.rs
@@ -29,7 +29,7 @@ const MESSAGES_LABEL: &str = "messages";
 pub struct ContractSync<I> {
     agent_name: String,
     home: String,
-    remote: String,
+    replica: String,
     db: NomadDB,
     indexer: Arc<I>,
     index_settings: IndexSettings,
@@ -53,7 +53,7 @@ impl<I> ContractSync<I> {
     pub fn new(
         agent_name: String,
         home: String,
-        remote: String,
+        replica: String,
         db: NomadDB,
         indexer: Arc<I>,
         index_settings: IndexSettings,
@@ -64,7 +64,7 @@ impl<I> ContractSync<I> {
         Self {
             agent_name,
             home,
-            remote,
+            replica,
             db,
             indexer,
             index_settings,
@@ -97,19 +97,19 @@ where
         let indexed_height = self.metrics.indexed_height.with_label_values(&[
             UPDATES_LABEL,
             &self.home,
-            &self.remote,
+            &self.replica,
             &self.agent_name,
         ]);
         let store_update_latency = self
             .metrics
             .store_event_latency
             .clone()
-            .with_label_values(&[UPDATES_LABEL, &self.home, &self.remote, &self.agent_name]);
+            .with_label_values(&[UPDATES_LABEL, &self.home, &self.replica, &self.agent_name]);
 
         let stored_updates = self.metrics.stored_events.with_label_values(&[
             UPDATES_LABEL,
             &self.home,
-            &self.remote,
+            &self.replica,
             &self.agent_name,
         ]);
 
@@ -253,14 +253,14 @@ where
         let indexed_height = self.metrics.indexed_height.with_label_values(&[
             MESSAGES_LABEL,
             &self.home,
-            &self.remote,
+            &self.replica,
             &self.agent_name,
         ]);
 
         let stored_messages = self.metrics.stored_events.with_label_values(&[
             MESSAGES_LABEL,
             &self.home,
-            &self.remote,
+            &self.replica,
             &self.agent_name,
         ]);
 

--- a/nomad-base/src/settings/mod.rs
+++ b/nomad-base/src/settings/mod.rs
@@ -249,6 +249,7 @@ impl Settings {
         Ok(ContractSync::new(
             agent_name.to_owned(),
             home_name.to_owned(),
+            home_name.to_owned(),
             nomad_db,
             indexer,
             index_settings,
@@ -303,6 +304,7 @@ impl Settings {
 
         Ok(ContractSync::new(
             agent_name.to_owned(),
+            self.home.name.clone(),
             replica_name.to_owned(),
             nomad_db,
             indexer,


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

Need clearer metrics on indexing updates (is it an update or is it a relayed update event?).

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

ContractSync take `home` and `replica` labels. If agent is indexing home, both labels will be same network.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests (N/A)
- [ ] Updated Documentation (N/A)
- [x] Updated CHANGELOG.md for the appropriate package 
