### PR TITLE
fix: prevent processor from attempting to run an empty select_all

### DIFF
--- a/agents/processor/CHANGELOG.md
+++ b/agents/processor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- bug: add check for empty intersection of specified and subsidized
 - refactor: processor now uses global AWS client when proof pushing is enabled
 - prevent processor from retrying messages it has previously attempted to
   process

--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -413,18 +413,15 @@ impl NomadAgent for Processor {
             let mut tasks = vec![home_sync_task, prover_sync_task, home_fail_watch_task];
 
             if !self.subsidized_remotes.is_empty() {
-                let specified_remotes: HashSet<String> =
-                    self.replicas().keys().map(String::to_owned).collect();
-
                 // Get intersection of specified remotes (replicas in settings)
                 // and subsidized remotes
                 let specified_subsidized: Vec<&str> = self
                     .subsidized_remotes
-                    .intersection(&specified_remotes)
-                    .collect::<Vec<_>>()
                     .iter()
-                    .map(|x| x.as_str())
+                    .filter(|r| self.replicas().contains_key(*r))
+                    .map(AsRef::as_ref)
                     .collect();
+
                 if !specified_subsidized.is_empty() {
                     tasks.push(self.run_many(&specified_subsidized));
                 }

--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -337,12 +337,21 @@ impl NomadAgent for Processor {
     where
         Self: Sized,
     {
+        // we filter this so that the agent doesn't think it should subsidize
+        // remotes it is unaware of
+        let subsidized_remotes = settings
+            .agent
+            .subsidized_remotes
+            .iter()
+            .filter(|r| settings.base.replicas.contains_key(*r))
+            .cloned()
+            .collect();
         Ok(Self::new(
             settings.agent.interval,
             settings.as_ref().try_into_core(AGENT_NAME).await?,
             settings.agent.allowed,
             settings.agent.denied,
-            settings.agent.subsidized_remotes,
+            subsidized_remotes,
             settings.agent.s3,
         ))
     }

--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -425,8 +425,9 @@ impl NomadAgent for Processor {
                     .iter()
                     .map(|x| x.as_str())
                     .collect();
-
-                tasks.push(self.run_many(&specified_subsidized));
+                if !specified_subsidized.is_empty() {
+                    tasks.push(self.run_many(&specified_subsidized));
+                }
             }
 
             // if we have a bucket, add a task to push to it

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- bug: add checks for empty replica name arrays in `NomadAgent::run_many` and
+  `NomadAgent::run_all`
 - add `previously_attempted` to the DB schema
 - remove `enabled` flag from agents project-wide
 - adds a changelog

--- a/nomad-base/src/agent.rs
+++ b/nomad-base/src/agent.rs
@@ -167,6 +167,12 @@ pub trait NomadAgent: Send + Sync + Sized + std::fmt::Debug + AsRef<AgentCore> {
     #[allow(clippy::unit_arg)]
     fn run_many(&self, replicas: &[&str]) -> Instrumented<JoinHandle<Result<()>>> {
         let span = info_span!("run_many");
+
+        // easy check that the slice is non-empty
+        replicas
+            .first()
+            .expect("Attempted to run without any replicas");
+
         let handles: Vec<_> = replicas
             .iter()
             .map(|replica| self.run_report_error(replica.to_string()))
@@ -195,6 +201,11 @@ pub trait NomadAgent: Send + Sync + Sized + std::fmt::Debug + AsRef<AgentCore> {
         tokio::spawn(async move {
             // this is the unused must use
             let names: Vec<&str> = self.replicas().keys().map(|k| k.as_str()).collect();
+
+            // quick check that at least 1 replica is configured
+            names
+                .first()
+                .expect("Attempted to run without any replicas");
 
             let run_task = self.run_many(&names);
             let mut tasks = vec![run_task];


### PR DESCRIPTION

## Motivation

Processor was encountering a panic when running with only an ethereum remote

```
Message:  assertion failed: !ret.inner.is_empty()
Location: /home/runner/.cargo/registry/src/github.com-1ecc6299db9ec823/futures-util-0.3.21/src/future/select_all.rs:40
```

- the error occurs because `futures_util::select_all` is invoked with an empty vector. 
- the only place where this could occur **in our code** is in `NomadAgent::run_many` which calls `select_all` on the result of an iterator
    - `grep -ri --include="*.rs" "select_all" *` will identify locations where `select_all` is invoked
- this iterator may only be empty if the names slice is empty when called
- `NomadAgent::run_many` is invoked from `NomadAgent::run_all`
- it is also invoked from `<Processor as **NomadAgent>::run_all` overriding the default trait impl

- the `<Processor as NomadAgent>::run_all` would run certain tasks ONLY for subsidized networks
- it would do this by loading the `subsidized_networks` and calculating the intersection with `remote_networks`, and making a task for each network in the intersection
- this would result in an empty task vector if no subsidized networks were specified in `remote_networks`

## Solution

- Adds checks that replica is non-empty to the default implementations of `NomadAgent::run_all` and `NomadAgent::run_many`
- Add check that `specified_subsidized` is not empty when running `select_all` in `<Processor as NomadAgent>::run_all`
- Filter `subsidized_remotes` by inclusion in `remote_networks` to prevent similar errors in the future

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
