### PR TITLE
feature: add a tracing subscriber to capture and emit agent bootup events

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2657,6 +2657,7 @@ dependencies = [
  "serde_yaml",
  "serial_test",
  "tokio",
+ "tracing",
  "wasm-bindgen",
  "wee_alloc",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -220,7 +220,7 @@ name = "balance-exporter"
 version = "0.1.0"
 dependencies = [
  "clap 3.1.18",
- "color-eyre 0.6.1",
+ "color-eyre",
  "ethers-core",
  "futures",
  "human-panic",
@@ -674,44 +674,17 @@ dependencies = [
 
 [[package]]
 name = "color-eyre"
-version = "0.5.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f1885697ee8a177096d42f158922251a41973117f6d8a234cee94b9509157b7"
-dependencies = [
- "backtrace",
- "color-spantrace 0.1.6",
- "eyre",
- "indenter",
- "once_cell",
- "owo-colors 1.3.0",
- "tracing-error 0.1.2",
-]
-
-[[package]]
-name = "color-eyre"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ebf286c900a6d5867aeff75cfee3192857bb7f24b547d4f0df2ed6baa812c90"
 dependencies = [
  "backtrace",
- "color-spantrace 0.2.0",
+ "color-spantrace",
  "eyre",
  "indenter",
  "once_cell",
- "owo-colors 3.4.0",
- "tracing-error 0.2.0",
-]
-
-[[package]]
-name = "color-spantrace"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6eee477a4a8a72f4addd4de416eb56d54bc307b284d6601bafdee1f4ea462d1"
-dependencies = [
- "once_cell",
- "owo-colors 1.3.0",
- "tracing-core",
- "tracing-error 0.1.2",
+ "owo-colors",
+ "tracing-error",
 ]
 
 [[package]]
@@ -721,9 +694,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ba75b3d9449ecdccb27ecbc479fdc0b87fa2dd43d2f8298f9bf0e59aacc8dce"
 dependencies = [
  "once_cell",
- "owo-colors 3.4.0",
+ "owo-colors",
  "tracing-core",
- "tracing-error 0.2.0",
+ "tracing-error",
 ]
 
 [[package]]
@@ -2025,7 +1998,7 @@ version = "1.0.0"
 dependencies = [
  "affix",
  "async-trait",
- "color-eyre 0.5.11",
+ "color-eyre",
  "config 0.10.1",
  "dotenv",
  "ethers",
@@ -2045,7 +2018,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.14",
 ]
 
 [[package]]
@@ -2059,7 +2032,7 @@ name = "kms-cli"
 version = "0.1.0"
 dependencies = [
  "clap 3.1.18",
- "color-eyre 0.5.11",
+ "color-eyre",
  "ethers",
  "ethers-signers",
  "hex",
@@ -2210,15 +2183,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b823e83b2affd8f40a9ee8c29dbc56404c1e34cd2710921f2801e2cf29527afa"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "matchers"
-version = "0.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f099785f7595cc4b4553a174ce30dd7589ef93391ff414dbb67f62392b9e0ce1"
-dependencies = [
- "regex-automata",
 ]
 
 [[package]]
@@ -2490,7 +2454,7 @@ version = "0.1.0"
 dependencies = [
  "affix",
  "async-trait",
- "color-eyre 0.5.11",
+ "color-eyre",
  "ethers",
  "futures-util",
  "mockall 0.10.2",
@@ -2511,10 +2475,10 @@ dependencies = [
  "thiserror",
  "tokio",
  "tracing",
- "tracing-error 0.1.2",
+ "tracing-error",
  "tracing-futures",
  "tracing-opentelemetry",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.14",
  "warp",
 ]
 
@@ -2522,7 +2486,7 @@ dependencies = [
 name = "nomad-cli"
 version = "0.1.0"
 dependencies = [
- "color-eyre 0.5.11",
+ "color-eyre",
  "ethers",
  "ethers-signers",
  "hex",
@@ -2544,7 +2508,7 @@ dependencies = [
  "accumulator",
  "async-trait",
  "bytes",
- "color-eyre 0.5.11",
+ "color-eyre",
  "ethers",
  "ethers-providers",
  "ethers-signers",
@@ -2574,7 +2538,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
- "color-eyre 0.5.11",
+ "color-eyre",
  "ethers",
  "ethers-contract",
  "ethers-core",
@@ -2605,7 +2569,7 @@ name = "nomad-test"
 version = "0.1.0"
 dependencies = [
  "async-trait",
- "color-eyre 0.5.11",
+ "color-eyre",
  "config 0.10.1",
  "dotenv",
  "ethers",
@@ -2629,14 +2593,13 @@ name = "nomad-types"
 version = "0.1.0"
 dependencies = [
  "affix",
- "color-eyre 0.5.11",
+ "color-eyre",
  "ethers",
  "hex",
  "prometheus",
  "serde 1.0.137",
  "serde_json",
  "thiserror",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -2871,12 +2834,6 @@ checksum = "c3df761f6470298359f84fcfb60d86db02acc22c251c37265c07a3d1057d2389"
 dependencies = [
  "regex",
 ]
-
-[[package]]
-name = "owo-colors"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2386b4ebe91c2f7f51082d4cefa145d030e33a1842a96b12e4885cc3c01f7a55"
 
 [[package]]
 name = "owo-colors"
@@ -3251,7 +3208,7 @@ version = "1.0.0"
 dependencies = [
  "affix",
  "async-trait",
- "color-eyre 0.5.11",
+ "color-eyre",
  "config 0.10.1",
  "dotenv",
  "ethers",
@@ -3273,7 +3230,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.14",
 ]
 
 [[package]]
@@ -3435,15 +3392,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "regex-automata"
-version = "0.1.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
-dependencies = [
- "regex-syntax",
-]
-
-[[package]]
 name = "regex-syntax"
 version = "0.6.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3455,7 +3403,7 @@ version = "1.0.0"
 dependencies = [
  "affix",
  "async-trait",
- "color-eyre 0.5.11",
+ "color-eyre",
  "config 0.10.1",
  "dotenv",
  "ethers",
@@ -3474,7 +3422,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.14",
 ]
 
 [[package]]
@@ -4599,22 +4547,12 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.27"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7709595b8878a4965ce5e87ebf880a7d39c9afc6837721b21a5a816a8117d921"
+checksum = "7b7358be39f2f274f322d2aaed611acc57f382e8eb1e5b48cb9ae30933495ce7"
 dependencies = [
  "once_cell",
  "valuable",
-]
-
-[[package]]
-name = "tracing-error"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4d7c0b83d4a500748fa5879461652b361edf5c9d51ede2a2ac03875ca185e24"
-dependencies = [
- "tracing",
- "tracing-subscriber 0.2.25",
 ]
 
 [[package]]
@@ -4624,7 +4562,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d686ec1c0f384b1277f097b2f279a2ecc11afe8c133c1aabf036a27cb4cd206e"
 dependencies = [
  "tracing",
- "tracing-subscriber 0.3.11",
+ "tracing-subscriber 0.3.14",
 ]
 
 [[package]]
@@ -4677,31 +4615,26 @@ version = "0.2.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0e0d2eaa99c3c2e41547cfa109e910a68ea03823cccad4a0525dcbc9b01e8c71"
 dependencies = [
+ "sharded-slab",
+ "thread_local",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-subscriber"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a713421342a5a666b7577783721d3117f1b69a393df803ee17bb73b1e122a59"
+dependencies = [
  "ansi_term",
- "chrono",
- "lazy_static",
- "matchers",
- "regex",
  "serde 1.0.137",
  "serde_json",
  "sharded-slab",
  "smallvec",
  "thread_local",
- "tracing",
  "tracing-core",
  "tracing-log",
  "tracing-serde",
-]
-
-[[package]]
-name = "tracing-subscriber"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4bc28f93baff38037f64e6f43d34cfa1605f27a49c34e8a04c5e78b0babf2596"
-dependencies = [
- "sharded-slab",
- "thread_local",
- "tracing-core",
 ]
 
 [[package]]
@@ -4837,7 +4770,7 @@ version = "1.0.0"
 dependencies = [
  "affix",
  "async-trait",
- "color-eyre 0.5.11",
+ "color-eyre",
  "config 0.11.0",
  "dotenv",
  "ethers",
@@ -4859,7 +4792,7 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.14",
  "warp",
 ]
 
@@ -5067,7 +5000,7 @@ version = "1.0.0"
 dependencies = [
  "affix",
  "async-trait",
- "color-eyre 0.5.11",
+ "color-eyre",
  "config 0.10.1",
  "dotenv",
  "ethers",
@@ -5088,7 +5021,7 @@ dependencies = [
  "tokio-test",
  "tracing",
  "tracing-futures",
- "tracing-subscriber 0.2.25",
+ "tracing-subscriber 0.3.14",
 ]
 
 [[package]]

--- a/agents/kathy/CHANGELOG.md
+++ b/agents/kathy/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides
 - remove `enabled` flag from agents project-wide

--- a/agents/kathy/Cargo.toml
+++ b/agents/kathy/Cargo.toml
@@ -14,8 +14,8 @@ exclude = [
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-async-trait = {version = "0.1.42", default-features = false}
-color-eyre = "0.5.0"
+async-trait = { version = "0.1.42", default-features = false }
+color-eyre = "0.6.0"
 config = "0.10"
 ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 futures-util = "0.3.12"
@@ -24,9 +24,9 @@ serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0", default-features = false}
 thiserror = {version = "1.0.22", default-features = false}
 tokio = {version = "1.0.1", features = ["rt", "macros"]}
-tracing = "0.1.22"
-tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.15"
+tracing = "0.1.35"
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.3.14"
 rand = "0.8.3"
 prometheus = "0.12"
 nomad-xyz-configuration = { path = "../../configuration" }

--- a/agents/kathy/src/main.rs
+++ b/agents/kathy/src/main.rs
@@ -11,29 +11,29 @@ use crate::{kathy::Kathy, settings::KathySettings as Settings};
 use color_eyre::Result;
 use nomad_base::NomadAgent;
 
-use tracing::{info_span, Level};
+use tracing::info_span;
 use tracing_subscriber::prelude::*;
 
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let agent = {
-        // sets the subscriber for this scope only
-        let _sub = tracing_subscriber::FmtSubscriber::builder()
-            .json()
-            .with_max_level(Level::DEBUG)
-            .with_level(true)
-            .set_default();
-        {
-            let span = info_span!("KathyBootup");
-            let _span = span.enter();
 
-            let settings = Settings::new()?;
-            Kathy::from_settings(settings).await?
-        }
-    };
+    let _bootup_guard = tracing_subscriber::FmtSubscriber::builder()
+        .json()
+        .with_level(true)
+        .set_default();
 
-    let metrics_guard = agent.start_tracing(agent.metrics().span_duration());
+    let span = info_span!("KathyBootup");
+    let _span = span.enter();
+
+    let settings = Settings::new()?;
+    let agent = Kathy::from_settings(settings).await?;
+
+    drop(_span);
+    drop(span);
+
+    let _tracing_guard = agent.start_tracing(agent.metrics().span_duration());
+
     let _ = agent.metrics().run_http_server();
 
     agent.run_all().await?

--- a/agents/kathy/src/main.rs
+++ b/agents/kathy/src/main.rs
@@ -11,12 +11,20 @@ use crate::{kathy::Kathy, settings::KathySettings as Settings};
 use color_eyre::Result;
 use nomad_base::NomadAgent;
 
+use tracing_subscriber::prelude::*;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let settings = Settings::new()?;
-
-    let agent = Kathy::from_settings(settings).await?;
+    let agent = {
+        // sets the subscriber for this scope only
+        let _ = tracing_subscriber::FmtSubscriber::builder()
+            .json()
+            .with_level(true)
+            .set_default();
+        let settings = Settings::new()?;
+        Kathy::from_settings(settings).await?
+    };
 
     agent.start_tracing(agent.metrics().span_duration())?;
     let _ = agent.metrics().run_http_server();

--- a/agents/kathy/src/main.rs
+++ b/agents/kathy/src/main.rs
@@ -33,7 +33,7 @@ async fn main() -> Result<()> {
         }
     };
 
-    agent.start_tracing(agent.metrics().span_duration())?;
+    let metrics_guard = agent.start_tracing(agent.metrics().span_duration());
     let _ = agent.metrics().run_http_server();
 
     agent.run_all().await?

--- a/agents/processor/CHANGELOG.md
+++ b/agents/processor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add bootup-only tracing subscriber
 - bug: add check for empty intersection of specified and subsidized
 - refactor: processor now uses global AWS client when proof pushing is enabled
 - prevent processor from retrying messages it has previously attempted to

--- a/agents/processor/Cargo.toml
+++ b/agents/processor/Cargo.toml
@@ -21,10 +21,10 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
-color-eyre = "0.5.0"
-tracing = "0.1.22"
-tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.15"
+color-eyre = "0.6.0"
+tracing = "0.1.35"
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.3.14"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }
 affix = "0.1.2"
 prometheus = "0.12"

--- a/agents/processor/src/main.rs
+++ b/agents/processor/src/main.rs
@@ -14,6 +14,7 @@ mod push;
 mod settings;
 
 use color_eyre::Result;
+use tracing::info_span;
 
 use crate::{processor::Processor, settings::ProcessorSettings as Settings};
 use nomad_base::NomadAgent;
@@ -26,12 +27,17 @@ async fn main() -> Result<()> {
 
     let agent = {
         // sets the subscriber for this scope only
-        let _ = tracing_subscriber::FmtSubscriber::builder()
+        let _sub = tracing_subscriber::FmtSubscriber::builder()
             .json()
             .with_level(true)
             .set_default();
-        let settings = Settings::new()?;
-        Processor::from_settings(settings).await?
+        {
+            let span = info_span!("ProcessorBootup");
+            let _span = span.enter();
+
+            let settings = Settings::new()?;
+            Processor::from_settings(settings).await?
+        }
     };
 
     // TODO: top-level root span customizations?

--- a/agents/processor/src/main.rs
+++ b/agents/processor/src/main.rs
@@ -41,7 +41,7 @@ async fn main() -> Result<()> {
     };
 
     // TODO: top-level root span customizations?
-    agent.start_tracing(agent.metrics().span_duration())?;
+    let metrics_guard = agent.start_tracing(agent.metrics().span_duration());
 
     let _ = agent.metrics().run_http_server();
 

--- a/agents/processor/src/main.rs
+++ b/agents/processor/src/main.rs
@@ -18,13 +18,23 @@ use color_eyre::Result;
 use crate::{processor::Processor, settings::ProcessorSettings as Settings};
 use nomad_base::NomadAgent;
 
+use tracing_subscriber::prelude::*;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let settings = Settings::new()?;
+
+    let agent = {
+        // sets the subscriber for this scope only
+        let _ = tracing_subscriber::FmtSubscriber::builder()
+            .json()
+            .with_level(true)
+            .set_default();
+        let settings = Settings::new()?;
+        Processor::from_settings(settings).await?
+    };
 
     // TODO: top-level root span customizations?
-    let agent = Processor::from_settings(settings).await?;
     agent.start_tracing(agent.metrics().span_duration())?;
 
     let _ = agent.metrics().run_http_server();

--- a/agents/relayer/CHANGELOG.md
+++ b/agents/relayer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides
 - remove `enabled` flag from agents project-wide

--- a/agents/relayer/Cargo.toml
+++ b/agents/relayer/Cargo.toml
@@ -21,10 +21,10 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
-color-eyre = "0.5.0"
-tracing = "0.1.22"
-tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.15"
+color-eyre = "0.6.0"
+tracing = "0.1.35"
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.3.14"
 nomad-xyz-configuration = { path = "../../configuration" }
 
 nomad-core = { path = "../../nomad-core" }

--- a/agents/relayer/src/main.rs
+++ b/agents/relayer/src/main.rs
@@ -36,7 +36,7 @@ async fn main() -> Result<()> {
         }
     };
 
-    agent.start_tracing(agent.metrics().span_duration())?;
+    let metrics_guard = agent.start_tracing(agent.metrics().span_duration());
     let _ = agent.metrics().run_http_server();
 
     agent.run_all().await??;

--- a/agents/relayer/src/main.rs
+++ b/agents/relayer/src/main.rs
@@ -14,15 +14,23 @@ use crate::{relayer::Relayer, settings::RelayerSettings as Settings};
 use color_eyre::Result;
 use nomad_base::NomadAgent;
 
+use tracing_subscriber::prelude::*;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let settings = Settings::new()?;
 
-    let agent = Relayer::from_settings(settings).await?;
+    let agent = {
+        // sets the subscriber for this scope only
+        let _ = tracing_subscriber::FmtSubscriber::builder()
+            .json()
+            .with_level(true)
+            .set_default();
+        let settings = Settings::new()?;
+        Relayer::from_settings(settings).await?
+    };
 
     agent.start_tracing(agent.metrics().span_duration())?;
-
     let _ = agent.metrics().run_http_server();
 
     agent.run_all().await??;

--- a/agents/relayer/src/main.rs
+++ b/agents/relayer/src/main.rs
@@ -21,22 +21,22 @@ use tracing_subscriber::prelude::*;
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
-    let agent = {
-        // sets the subscriber for this scope only
-        let _sub = tracing_subscriber::FmtSubscriber::builder()
-            .json()
-            .with_level(true)
-            .set_default();
-        {
-            let span = info_span!("RelayerBootup");
-            let _span = span.enter();
+    let _bootup_guard = tracing_subscriber::FmtSubscriber::builder()
+        .json()
+        .with_level(true)
+        .set_default();
 
-            let settings = Settings::new()?;
-            Relayer::from_settings(settings).await?
-        }
-    };
+    let span = info_span!("RelayerBootup");
+    let _span = span.enter();
 
-    let metrics_guard = agent.start_tracing(agent.metrics().span_duration());
+    let settings = Settings::new()?;
+    let agent = Relayer::from_settings(settings).await?;
+
+    drop(_span);
+    drop(span);
+
+    let _tracing_guard = agent.start_tracing(agent.metrics().span_duration());
+
     let _ = agent.metrics().run_http_server();
 
     agent.run_all().await??;

--- a/agents/relayer/src/main.rs
+++ b/agents/relayer/src/main.rs
@@ -14,6 +14,7 @@ use crate::{relayer::Relayer, settings::RelayerSettings as Settings};
 use color_eyre::Result;
 use nomad_base::NomadAgent;
 
+use tracing::info_span;
 use tracing_subscriber::prelude::*;
 
 #[tokio::main(flavor = "current_thread")]
@@ -22,12 +23,17 @@ async fn main() -> Result<()> {
 
     let agent = {
         // sets the subscriber for this scope only
-        let _ = tracing_subscriber::FmtSubscriber::builder()
+        let _sub = tracing_subscriber::FmtSubscriber::builder()
             .json()
             .with_level(true)
             .set_default();
-        let settings = Settings::new()?;
-        Relayer::from_settings(settings).await?
+        {
+            let span = info_span!("RelayerBootup");
+            let _span = span.enter();
+
+            let settings = Settings::new()?;
+            Relayer::from_settings(settings).await?
+        }
     };
 
     agent.start_tracing(agent.metrics().span_duration())?;

--- a/agents/updater/CHANGELOG.md
+++ b/agents/updater/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides
 - remove `enabled` flag from agents project-wide

--- a/agents/updater/Cargo.toml
+++ b/agents/updater/Cargo.toml
@@ -21,10 +21,10 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
-color-eyre = "0.5.0"
-tracing = "0.1.22"
-tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.15"
+color-eyre = "0.6.0"
+tracing = "0.1.35"
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.3.14"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }
 nomad-xyz-configuration = { path = "../../configuration" }
 

--- a/agents/updater/src/main.rs
+++ b/agents/updater/src/main.rs
@@ -22,23 +22,22 @@ use tracing_subscriber::prelude::*;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let agent = {
-        // sets the subscriber for this scope only
-        let _sub = tracing_subscriber::FmtSubscriber::builder()
-            .json()
-            .with_level(true)
-            .set_default();
+    // sets the subscriber for this scope only
+    let _bootup_guard = tracing_subscriber::FmtSubscriber::builder()
+        .json()
+        .with_level(true)
+        .set_default();
 
-        {
-            let span = info_span!("UpdaterBootup");
-            let _span = span.enter();
+    let span = info_span!("UpdaterBootup");
+    let _span = span.enter();
 
-            let settings = Settings::new()?;
-            Updater::from_settings(settings).await?
-        }
-    };
+    let settings = Settings::new()?;
+    let agent = Updater::from_settings(settings).await?;
 
-    let metrics_guard = agent.start_tracing(agent.metrics().span_duration());
+    drop(_span);
+    drop(span);
+
+    let _tracing_guard = agent.start_tracing(agent.metrics().span_duration());
 
     let _ = agent.metrics().run_http_server();
 

--- a/agents/updater/src/main.rs
+++ b/agents/updater/src/main.rs
@@ -16,12 +16,20 @@ use crate::{settings::UpdaterSettings as Settings, updater::Updater};
 use color_eyre::Result;
 use nomad_base::NomadAgent;
 
+use tracing_subscriber::prelude::*;
+
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
-    let settings = Settings::new()?;
-
-    let agent = Updater::from_settings(settings).await?;
+    let agent = {
+        // sets the subscriber for this scope only
+        let _ = tracing_subscriber::FmtSubscriber::builder()
+            .json()
+            .with_level(true)
+            .set_default();
+        let settings = Settings::new()?;
+        Updater::from_settings(settings).await?
+    };
 
     agent.start_tracing(agent.metrics().span_duration())?;
 

--- a/agents/updater/src/main.rs
+++ b/agents/updater/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
         }
     };
 
-    agent.start_tracing(agent.metrics().span_duration())?;
+    let metrics_guard = agent.start_tracing(agent.metrics().span_duration());
 
     let _ = agent.metrics().run_http_server();
 

--- a/agents/watcher/CHANGELOG.md
+++ b/agents/watcher/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides
 - remove `enabled` flag from agents project-wide

--- a/agents/watcher/Cargo.toml
+++ b/agents/watcher/Cargo.toml
@@ -21,10 +21,10 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
-color-eyre = "0.5.0"
-tracing = "0.1.22"
-tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.15"
+color-eyre = "0.6.0"
+tracing = "0.1.35"
+tracing-futures = "0.2.5"
+tracing-subscriber = "0.3.14"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }
 prometheus = "0.12"
 nomad-xyz-configuration = { path = "../../configuration" }

--- a/agents/watcher/src/main.rs
+++ b/agents/watcher/src/main.rs
@@ -38,7 +38,7 @@ async fn main() -> Result<()> {
         }
     };
 
-    agent.start_tracing(agent.metrics().span_duration())?;
+    let metrics_guard = agent.start_tracing(agent.metrics().span_duration());
     let _ = agent.metrics().run_http_server();
 
     agent.run_all().await??;

--- a/agents/watcher/src/watcher.rs
+++ b/agents/watcher/src/watcher.rs
@@ -956,11 +956,11 @@ mod test {
                 home,
             };
 
-            let _first_update_ret = handler
+            handler
                 .check_double_update(&first_update)
                 .expect("Update should have been valid");
 
-            let _second_update_ret = handler
+            handler
                 .check_double_update(&second_update)
                 .expect("Update should have been valid");
 

--- a/chains/nomad-ethereum/Cargo.toml
+++ b/chains/nomad-ethereum/Cargo.toml
@@ -11,8 +11,8 @@ edition = "2021"
 serde = "1.0.120"
 serde_json = { version = "1.0.61", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
-tracing = "0.1.22"
-color-eyre = "0.5.0"
+tracing = "0.1.35"
+color-eyre = "0.6.0"
 anyhow = "1"
 num = "0.4"
 tokio = "1.7.1"

--- a/chains/nomad-ethereum/src/gas.rs
+++ b/chains/nomad-ethereum/src/gas.rs
@@ -79,7 +79,6 @@ where
         &self.inner
     }
 
-    #[allow(mutable_borrow_reservation_conflict)]
     async fn fill_transaction(
         &self,
         tx: &mut TypedTransaction,

--- a/chains/nomad-ethereum/src/home.rs
+++ b/chains/nomad-ethereum/src/home.rs
@@ -46,11 +46,18 @@ where
     pub fn new(
         provider: Arc<R>,
         ContractLocator {
-            name: _,
-            domain: _,
+            name,
+            domain,
             address,
         }: &ContractLocator,
     ) -> Self {
+        tracing::info!(
+            address = ?address.as_ethereum_address(),
+            name = name,
+            domain = domain,
+            "Connecting Home Indexer"
+        );
+
         Self {
             contract: Arc::new(EthereumHomeInternal::new(
                 address.as_ethereum_address().expect("!eth address"),
@@ -184,6 +191,12 @@ where
         }: &ContractLocator,
         gas: Option<HomeGasLimits>,
     ) -> Self {
+        tracing::info!(
+            address = ?address.as_ethereum_address(),
+            name = name,
+            domain = domain,
+            "Connecting Home"
+        );
         Self {
             submitter,
             contract: Arc::new(EthereumHomeInternal::new(

--- a/chains/nomad-ethereum/src/macros.rs
+++ b/chains/nomad-ethereum/src/macros.rs
@@ -78,9 +78,9 @@ macro_rules! boxed_indexer {
     (@timelag $provider:expr, $abi:ident, $timelag:ident, $($tail:tt)*) => {{
         if let Some(lag) = $timelag {
             let provider: Arc<_> = ethers::middleware::TimeLag::new($provider, lag).into();
-            Box::new(crate::$abi::new(provider, $($tail)*))
+            Box::new($crate::$abi::new(provider, $($tail)*))
         } else {
-            Box::new(crate::$abi::new($provider, $($tail)*))
+            Box::new($crate::$abi::new($provider, $($tail)*))
         }
     }};
     (@ws $url:expr, $($tail:tt)*) => {{
@@ -89,7 +89,7 @@ macro_rules! boxed_indexer {
         boxed_indexer!(@timelag provider, $($tail)*)
     }};
     (@http $url:expr, $($tail:tt)*) => {{
-        let provider: crate::retrying::RetryingProvider<ethers::providers::Http> = $url.parse()?;
+        let provider: $crate::retrying::RetryingProvider<ethers::providers::Http> = $url.parse()?;
         let provider = Arc::new(ethers::providers::Provider::new(provider));
         boxed_indexer!(@timelag provider, $($tail)*)
     }};
@@ -113,7 +113,7 @@ macro_rules! boxed_indexer {
 #[macro_export]
 macro_rules! http_provider {
     ($url:expr) => {{
-        let provider: crate::retrying::RetryingProvider<ethers::providers::Http> = $url.parse()?;
+        let provider: $crate::retrying::RetryingProvider<ethers::providers::Http> = $url.parse()?;
         Arc::new(ethers::providers::Provider::new(provider))
     }};
 }
@@ -142,7 +142,7 @@ macro_rules! wrap_with_signer {
 
         // Kludge. Increase the gas by multiplication of every estimated gas by
         // 2, except the gas for chain id 1 (Ethereum Mainnet)
-        let provider = crate::gas::GasAdjusterMiddleware::with_default_policy(
+        let provider = $crate::gas::GasAdjusterMiddleware::with_default_policy(
             provider,
             provider_chain_id.as_u64(),
         );
@@ -186,9 +186,9 @@ macro_rules! boxed_contract {
     (@timelag $base_provider:expr, $submitter:expr, $abi:ident, $timelag:ident, $($tail:tt)*) => {{
         if let Some(lag) = $timelag {
             let read_provider: Arc<_> = ethers::middleware::TimeLag::new($base_provider, lag).into();
-            Box::new(crate::$abi::new($submitter, read_provider, $($tail)*))
+            Box::new($crate::$abi::new($submitter, read_provider, $($tail)*))
         } else {
-            Box::new(crate::$abi::new($submitter, $base_provider, $($tail)*))
+            Box::new($crate::$abi::new($submitter, $base_provider, $($tail)*))
         }
     }};
     (@submitter $base_provider:expr, $submitter_conf:ident, $($tail:tt)*) => {{

--- a/chains/nomad-ethereum/src/replica.rs
+++ b/chains/nomad-ethereum/src/replica.rs
@@ -30,15 +30,21 @@ impl<R> EthereumReplicaIndexer<R>
 where
     R: ethers::providers::Middleware + 'static,
 {
-    /// Create new EthereumHomeIndexer
+    /// Create new EthereumReplicaIndexer
     pub fn new(
         provider: Arc<R>,
         ContractLocator {
-            name: _,
-            domain: _,
+            name,
+            domain,
             address,
         }: &ContractLocator,
     ) -> Self {
+        tracing::info!(
+            address = ?address.as_ethereum_address(),
+            name = name,
+            domain = domain,
+            "Connecting Replica Indexer"
+        );
         Self {
             contract: Arc::new(EthereumReplicaInternal::new(
                 address.as_ethereum_address().expect("!eth address"),
@@ -144,6 +150,12 @@ where
         }: &ContractLocator,
         gas: Option<ReplicaGasLimits>,
     ) -> Self {
+        tracing::info!(
+            address = ?address.as_ethereum_address(),
+            name = name,
+            domain = domain,
+            "Connecting Replica"
+        );
         Self {
             submitter,
             contract: Arc::new(EthereumReplicaInternal::new(

--- a/chains/nomad-ethereum/src/xapp.rs
+++ b/chains/nomad-ethereum/src/xapp.rs
@@ -38,12 +38,18 @@ where
         submitter: TxSubmitter<W>,
         read_provider: Arc<R>,
         ContractLocator {
-            name: _,
+            name,
             domain,
             address,
         }: &ContractLocator,
         gas: Option<ConnectionManagerGasLimits>,
     ) -> Self {
+        tracing::info!(
+            address = ?address.as_ethereum_address(),
+            name = name,
+            domain = domain,
+            "Connecting XappConnectionManager"
+        );
         Self {
             submitter,
             contract: Arc::new(EthereumConnectionManagerInternal::new(

--- a/configuration/Cargo.toml
+++ b/configuration/Cargo.toml
@@ -30,10 +30,10 @@ serde = "1.0.136"
 serde_json = "1.0.78"
 serde_yaml = "0.8.23"
 nomad-types = { path = "../nomad-types" }
+tracing = "0.1.35"
 
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 reqwest = "0.11.10"
-
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 wee_alloc = "0.4.5"

--- a/nomad-base/Cargo.toml
+++ b/nomad-base/Cargo.toml
@@ -14,10 +14,11 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
-color-eyre = "0.5.0"
-tracing = "0.1.22"
-tracing-futures = "0.2.4"
-tracing-subscriber = "0.2.15"
+color-eyre = "0.6.0"
+tracing = "0.1.35"
+tracing-futures = "0.2.5"
+tracing-error = "0.2.0"
+tracing-subscriber = { version = "0.3.14", features = ["json"] }
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }
 mockall = "0.10.2"
 rand = "0.8.3"
@@ -28,7 +29,6 @@ nomad-core = { path = "../nomad-core" }
 nomad-ethereum = { path = "../chains/nomad-ethereum"}
 nomad-test = { path = "../nomad-test" }
 affix = "0.1.2"
-tracing-error = "0.1.2"
 
 prometheus = "0.12"
 

--- a/nomad-base/src/settings/macros.rs
+++ b/nomad-base/src/settings/macros.rs
@@ -74,6 +74,7 @@ macro_rules! decl_settings {
             impl [<$name Settings>] {
                 pub fn new() -> color_eyre::Result<Self>{
                     // Get agent and home names
+                    tracing::info!("Building settings from env");
                     let agent = std::stringify!($name).to_lowercase();
                     let home = std::env::var("AGENT_HOME_NAME").expect("missing AGENT_HOME_NAME");
 

--- a/nomad-base/src/settings/trace/fmt.rs
+++ b/nomad-base/src/settings/trace/fmt.rs
@@ -94,17 +94,17 @@ where
         }
     }
 
-    fn new_span(
+    fn on_new_span(
         &self,
         attrs: &span::Attributes<'_>,
         id: &span::Id,
         ctx: tracing_subscriber::layer::Context<'_, S>,
     ) {
         match self {
-            LogOutputLayer::Full(inner) => inner.new_span(attrs, id, ctx),
-            LogOutputLayer::Pretty(inner) => inner.new_span(attrs, id, ctx),
-            LogOutputLayer::Compact(inner) => inner.new_span(attrs, id, ctx),
-            LogOutputLayer::Json(inner) => inner.new_span(attrs, id, ctx),
+            LogOutputLayer::Full(inner) => inner.on_new_span(attrs, id, ctx),
+            LogOutputLayer::Pretty(inner) => inner.on_new_span(attrs, id, ctx),
+            LogOutputLayer::Compact(inner) => inner.on_new_span(attrs, id, ctx),
+            LogOutputLayer::Json(inner) => inner.on_new_span(attrs, id, ctx),
         }
     }
 

--- a/nomad-base/src/settings/trace/span_metrics.rs
+++ b/nomad-base/src/settings/trace/span_metrics.rs
@@ -22,7 +22,7 @@ impl<S> Layer<S> for TimeSpanLifetime
 where
     S: Subscriber + for<'a> LookupSpan<'a>,
 {
-    fn new_span(&self, _: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
+    fn on_new_span(&self, _: &span::Attributes<'_>, id: &span::Id, ctx: Context<'_, S>) {
         match ctx.span(id) {
             Some(span) => span.extensions_mut().insert(SpanTiming {
                 start: Instant::now(),

--- a/nomad-core/Cargo.toml
+++ b/nomad-core/Cargo.toml
@@ -15,11 +15,11 @@ sha3 = "0.9.1"
 thiserror = "*"
 async-trait = { version = "0.1.42", default-features = false }
 tokio = { version = "1.0.1", features = ["rt", "macros"] }
-tracing = "0.1.22"
-tracing-futures = "0.2.4"
+tracing = "0.1.35"
+tracing-futures = "0.2.5"
 serde = {version = "1.0", features = ["derive"]}
 serde_json = {version = "1.0"}
-color-eyre = "0.5.0"
+color-eyre = "0.6.0"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }
 prometheus = "0.12.0"
 bytes = { version = "1", features = ["serde"]}

--- a/nomad-test/Cargo.toml
+++ b/nomad-test/Cargo.toml
@@ -13,12 +13,12 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 thiserror = { version = "1.0.22", default-features = false }
 async-trait = { version = "0.1.42", default-features = false }
 futures-util = "0.3.12"
-color-eyre = "0.5.0"
+color-eyre = "0.6.0"
 mockall = "0.10.2"
 rand = "0.8.3"
 rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }
 dotenv = "0.15.0"
-tracing = "0.1.26"
+tracing = "0.1.35"
 prometheus = "0.12.0"
 
 nomad-xyz-configuration = { path = "../configuration" }

--- a/nomad-test/src/test_utils.rs
+++ b/nomad-test/src/test_utils.rs
@@ -70,7 +70,7 @@ where
 
 pub fn clear_env_vars() {
     let env_vars = env::vars();
-    for (key, _) in env_vars.into_iter() {
+    for (key, _) in env_vars {
         env::remove_var(key);
     }
 }

--- a/nomad-types/Cargo.toml
+++ b/nomad-types/Cargo.toml
@@ -11,8 +11,7 @@ ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = { version = "1.0", default-features = false }
 thiserror = "*"
-tracing-subscriber = "0.2.15"
 prometheus = "0.12"
 affix = "0.1.2"
-color-eyre = "0.5.0"
+color-eyre = "0.6.0"
 hex = "0.4.3"

--- a/rust-toolchain
+++ b/rust-toolchain
@@ -1,3 +1,3 @@
 [toolchain]
-channel = "1.57"
+channel = "1.62"
 profile = "default"

--- a/tools/kms-cli/Cargo.toml
+++ b/tools/kms-cli/Cargo.toml
@@ -7,7 +7,7 @@ edition = "2021"
 
 [dependencies]
 clap = { version = "3.1.6", features = ["derive"] }
-color-eyre = "0.5.11"
+color-eyre = "0.6.0"
 ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 ethers-signers = { git = "https://github.com/gakonst/ethers-rs", branch = "master", features = ["aws"] }
 hex = "0.4.3"

--- a/tools/nomad-cli/Cargo.toml
+++ b/tools/nomad-cli/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-color-eyre = "0.5.11"
+color-eyre = "0.6.0"
 ethers = { git = "https://github.com/gakonst/ethers-rs", branch = "master" }
 ethers-signers = { git = "https://github.com/gakonst/ethers-rs", branch = "master", features = ["aws"] }
 hex = "0.4.3"


### PR DESCRIPTION

## Motivation

Tracing events are not currently emitted during agent bootup, as no subscriber is set

## Solution

Set a default subscriber in the agent main functions during bootup only. Drop the subscriber before full tracing is started

## Future Work

De-couple tracing config from agent state config. Use the tracing config for the whole process

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
