### PR TITLE
feat(configuration): make config url overridable via env var

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -120,6 +120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde 1.0.137",
+ "serde_json",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2386,6 +2396,24 @@ dependencies = [
 ]
 
 [[package]]
+name = "mockito"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "401edc088069634afaa5f4a29617b36dba683c0c16fe4435a86debad23fa2f1a"
+dependencies = [
+ "assert-json-diff",
+ "colored",
+ "httparse",
+ "lazy_static",
+ "log",
+ "rand",
+ "regex",
+ "serde_json",
+ "serde_urlencoded",
+ "similar",
+]
+
+[[package]]
 name = "multipart"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2575,6 +2603,7 @@ dependencies = [
  "ethers",
  "futures-util",
  "mockall 0.10.2",
+ "mockito",
  "nomad-core",
  "nomad-ethereum",
  "nomad-xyz-configuration",
@@ -4093,6 +4122,12 @@ dependencies = [
  "digest 0.9.0",
  "rand_core",
 ]
+
+[[package]]
+name = "similar"
+version = "2.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e24979f63a11545f5f2c60141afe249d4f19f84581ea2138065e400941d83d3"
 
 [[package]]
 name = "siphasher"

--- a/agents/kathy/CHANGELOG.md
+++ b/agents/kathy/CHANGELOG.md
@@ -2,7 +2,8 @@
 
 ### Unreleased
 
-- add environment variable override for remote config uri
+- make *Settings::new async for optionally fetching config from a remote url
+- add test for remote config fetch
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/agents/kathy/CHANGELOG.md
+++ b/agents/kathy/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add environment variable override for remote config uri
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/agents/kathy/src/main.rs
+++ b/agents/kathy/src/main.rs
@@ -18,6 +18,7 @@ use tracing_subscriber::prelude::*;
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
+    // sets the subscriber for this scope only
     let _bootup_guard = tracing_subscriber::FmtSubscriber::builder()
         .json()
         .with_level(true)
@@ -26,7 +27,7 @@ async fn main() -> Result<()> {
     let span = info_span!("KathyBootup");
     let _span = span.enter();
 
-    let settings = Settings::new()?;
+    let settings = Settings::new().await?;
     let agent = Kathy::from_settings(settings).await?;
 
     drop(_span);
@@ -36,5 +37,6 @@ async fn main() -> Result<()> {
 
     let _ = agent.metrics().run_http_server();
 
-    agent.run_all().await?
+    agent.run_all().await??;
+    Ok(())
 }

--- a/agents/kathy/src/settings.rs
+++ b/agents/kathy/src/settings.rs
@@ -23,8 +23,8 @@ mod test {
         test_utils::run_test_with_env_http(
             "../../fixtures/env.external",
             config_json,
-            |uri| async move {
-                std::env::set_var("CONFIG_URI", uri);
+            |url| async move {
+                std::env::set_var("CONFIG_URL", url);
 
                 let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
 

--- a/agents/kathy/src/settings.rs
+++ b/agents/kathy/src/settings.rs
@@ -11,15 +11,61 @@ mod test {
     use nomad_base::{get_remotes_from_env, NomadAgent};
     use nomad_test::test_utils;
     use nomad_xyz_configuration::{agent::kathy::ChatGenConfig, AgentSecrets};
+    use serde_json::json;
 
-    #[test]
+    #[tokio::test]
     #[serial_test::serial]
-    fn it_overrides_settings_from_env() {
-        test_utils::run_test_with_env_sync("../../fixtures/env.test-agents", move || {
+    async fn it_loads_remote_config() {
+        let config =
+            nomad_xyz_configuration::NomadConfig::from_file("../../fixtures/external_config.json")
+                .unwrap();
+        let config_json = json!(config).to_string();
+        test_utils::run_test_with_env_http(
+            "../../fixtures/env.external",
+            config_json,
+            |uri| async move {
+                std::env::set_var("CONFIG_URI", uri);
+
+                let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
+
+                let settings = KathySettings::new().await.unwrap();
+
+                let remotes = get_remotes_from_env!(agent_home, config);
+                let mut networks = remotes.clone();
+                networks.insert(agent_home.clone());
+
+                let secrets = AgentSecrets::from_env(&networks).unwrap();
+                secrets
+                    .validate("kathy", &networks)
+                    .expect("!secrets validate");
+
+                settings
+                    .base
+                    .validate_against_config_and_secrets(
+                        crate::Kathy::AGENT_NAME,
+                        &agent_home,
+                        &remotes,
+                        &config,
+                        &secrets,
+                    )
+                    .unwrap();
+
+                let agent_config = &config.agent().get("ethereum").unwrap().kathy;
+                assert_eq!(settings.agent.interval, agent_config.interval);
+                assert_eq!(settings.agent.chat, agent_config.chat);
+            },
+        )
+        .await
+    }
+
+    #[tokio::test]
+    #[serial_test::serial]
+    async fn it_overrides_settings_from_env() {
+        test_utils::run_test_with_env("../../fixtures/env.test-agents", || async move {
             let run_env = dotenv::var("RUN_ENV").unwrap();
             let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
 
-            let settings = KathySettings::new().unwrap();
+            let settings = KathySettings::new().await.unwrap();
 
             let config = nomad_xyz_configuration::get_builtin(&run_env).unwrap();
 

--- a/agents/kathy/src/settings.rs
+++ b/agents/kathy/src/settings.rs
@@ -20,10 +20,8 @@ mod test {
             nomad_xyz_configuration::NomadConfig::from_file("../../fixtures/external_config.json")
                 .unwrap();
         let config_json = json!(config).to_string();
-        test_utils::run_test_with_env_http(
-            "../../fixtures/env.external",
-            config_json,
-            |url| async move {
+        test_utils::run_test_with_http_response(config_json, |url| async move {
+            test_utils::run_test_with_env("../../fixtures/env.test-agents", || async move {
                 std::env::set_var("CONFIG_URL", url);
 
                 let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
@@ -53,8 +51,9 @@ mod test {
                 let agent_config = &config.agent().get("ethereum").unwrap().kathy;
                 assert_eq!(settings.agent.interval, agent_config.interval);
                 assert_eq!(settings.agent.chat, agent_config.chat);
-            },
-        )
+            })
+            .await
+        })
         .await
     }
 

--- a/agents/kathy/src/settings.rs
+++ b/agents/kathy/src/settings.rs
@@ -50,7 +50,8 @@ mod test {
                 }
             );
             assert_eq!(settings.agent.interval, 999);
-        });
+        })
+        .await
     }
 
     async fn test_build_from_env_file(path: &str) {
@@ -58,7 +59,7 @@ mod test {
             let run_env = dotenv::var("RUN_ENV").unwrap();
             let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
 
-            let settings = KathySettings::new().unwrap();
+            let settings = KathySettings::new().await.unwrap();
 
             let config = nomad_xyz_configuration::get_builtin(&run_env).unwrap();
 
@@ -108,7 +109,7 @@ mod test {
             std::env::set_var("CONFIG_PATH", "../../fixtures/external_config.json");
             let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
 
-            let settings = KathySettings::new().unwrap();
+            let settings = KathySettings::new().await.unwrap();
 
             let config = nomad_xyz_configuration::NomadConfig::from_file(
                 "../../fixtures/external_config.json",

--- a/agents/processor/CHANGELOG.md
+++ b/agents/processor/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add environment variable override for remote config uri
 - add bootup-only tracing subscriber
 - bug: add check for empty intersection of specified and subsidized
 - refactor: processor now uses global AWS client when proof pushing is enabled

--- a/agents/processor/CHANGELOG.md
+++ b/agents/processor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- add environment variable override for remote config uri
+- make *Settings::new async for optionally fetching config from a remote url
 - add bootup-only tracing subscriber
 - bug: add check for empty intersection of specified and subsidized
 - refactor: processor now uses global AWS client when proof pushing is enabled

--- a/agents/processor/src/main.rs
+++ b/agents/processor/src/main.rs
@@ -25,6 +25,7 @@ use tracing_subscriber::prelude::*;
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
+    // sets the subscriber for this scope only
     let _bootup_guard = tracing_subscriber::FmtSubscriber::builder()
         .json()
         .with_level(true)
@@ -33,7 +34,7 @@ async fn main() -> Result<()> {
     let span = info_span!("ProcessorBootup");
     let _span = span.enter();
 
-    let settings = Settings::new()?;
+    let settings = Settings::new().await?;
     let agent = Processor::from_settings(settings).await?;
 
     drop(_span);

--- a/agents/processor/src/settings.rs
+++ b/agents/processor/src/settings.rs
@@ -19,7 +19,7 @@ mod test {
             let run_env = dotenv::var("RUN_ENV").unwrap();
             let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
 
-            let settings = ProcessorSettings::new().unwrap();
+            let settings = ProcessorSettings::new().await.unwrap();
 
             let config = nomad_xyz_configuration::get_builtin(&run_env).unwrap();
 

--- a/agents/relayer/CHANGELOG.md
+++ b/agents/relayer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- add environment variable override for remote config uri
+- make *Settings::new async for optionally fetching config from a remote url
 - relayer checks replica updater addresses match, errors channel if otherwise
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration

--- a/agents/relayer/CHANGELOG.md
+++ b/agents/relayer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add environment variable override for remote config uri
 - relayer checks replica updater addresses match, errors channel if otherwise
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration

--- a/agents/relayer/src/main.rs
+++ b/agents/relayer/src/main.rs
@@ -21,6 +21,7 @@ use tracing_subscriber::prelude::*;
 async fn main() -> Result<()> {
     color_eyre::install()?;
 
+    // sets the subscriber for this scope only
     let _bootup_guard = tracing_subscriber::FmtSubscriber::builder()
         .json()
         .with_level(true)
@@ -29,7 +30,7 @@ async fn main() -> Result<()> {
     let span = info_span!("RelayerBootup");
     let _span = span.enter();
 
-    let settings = Settings::new()?;
+    let settings = Settings::new().await?;
     let agent = Relayer::from_settings(settings).await?;
 
     drop(_span);

--- a/agents/relayer/src/settings.rs
+++ b/agents/relayer/src/settings.rs
@@ -19,7 +19,7 @@ mod test {
             let run_env = dotenv::var("RUN_ENV").unwrap();
             let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
 
-            let settings = RelayerSettings::new().unwrap();
+            let settings = RelayerSettings::new().await.unwrap();
 
             let config = nomad_xyz_configuration::get_builtin(&run_env).unwrap();
 

--- a/agents/updater/CHANGELOG.md
+++ b/agents/updater/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add environment variable override for remote config uri
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/agents/updater/CHANGELOG.md
+++ b/agents/updater/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- add environment variable override for remote config uri
+- make *Settings::new async for optionally fetching config from a remote url
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/agents/updater/src/main.rs
+++ b/agents/updater/src/main.rs
@@ -22,6 +22,7 @@ use tracing_subscriber::prelude::*;
 #[tokio::main(flavor = "current_thread")]
 async fn main() -> Result<()> {
     color_eyre::install()?;
+
     // sets the subscriber for this scope only
     let _bootup_guard = tracing_subscriber::FmtSubscriber::builder()
         .json()
@@ -31,7 +32,7 @@ async fn main() -> Result<()> {
     let span = info_span!("UpdaterBootup");
     let _span = span.enter();
 
-    let settings = Settings::new()?;
+    let settings = Settings::new().await?;
     let agent = Updater::from_settings(settings).await?;
 
     drop(_span);

--- a/agents/updater/src/settings.rs
+++ b/agents/updater/src/settings.rs
@@ -18,7 +18,7 @@ mod test {
             let run_env = dotenv::var("RUN_ENV").unwrap();
             let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
 
-            let settings = UpdaterSettings::new().unwrap();
+            let settings = UpdaterSettings::new().await.unwrap();
 
             let config = nomad_xyz_configuration::get_builtin(&run_env).unwrap();
 

--- a/agents/watcher/CHANGELOG.md
+++ b/agents/watcher/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add environment variable override for remote config uri
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/agents/watcher/CHANGELOG.md
+++ b/agents/watcher/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- add environment variable override for remote config uri
+- make *Settings::new async for optionally fetching config from a remote url
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/agents/watcher/src/main.rs
+++ b/agents/watcher/src/main.rs
@@ -32,13 +32,14 @@ async fn main() -> Result<()> {
     let span = info_span!("WatcherBootup");
     let _span = span.enter();
 
-    let settings = Settings::new()?;
+    let settings = Settings::new().await?;
     let agent = Watcher::from_settings(settings).await?;
 
     drop(_span);
     drop(span);
 
     let _tracing_guard = agent.start_tracing(agent.metrics().span_duration());
+
     let _ = agent.metrics().run_http_server();
 
     agent.run_all().await??;

--- a/agents/watcher/src/settings.rs
+++ b/agents/watcher/src/settings.rs
@@ -19,7 +19,7 @@ mod test {
             let run_env = dotenv::var("RUN_ENV").unwrap();
             let agent_home = dotenv::var("AGENT_HOME_NAME").unwrap();
 
-            let settings = WatcherSettings::new().unwrap();
+            let settings = WatcherSettings::new().await.unwrap();
 
             let config = nomad_xyz_configuration::get_builtin(&run_env).unwrap();
 

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add environment variable override for remote config uri
 - feature: pull config files from github pages instead of local versions
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,7 +2,6 @@
 
 ### Unreleased
 
-- add environment variable override for remote config uri
 - feature: pull config files from github pages instead of local versions
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- add environment variable override for remote config uri
+- add `CONFIG_URL` check to `decl_settings` to optionally fetch config from a remote url
 - bug: add checks for empty replica name arrays in `NomadAgent::run_many` and
   `NomadAgent::run_all`
 - add `previously_attempted` to the DB schema

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- add environment variable override for remote config uri
 - bug: add checks for empty replica name arrays in `NomadAgent::run_many` and
   `NomadAgent::run_all`
 - add `previously_attempted` to the DB schema

--- a/nomad-base/src/settings/macros.rs
+++ b/nomad-base/src/settings/macros.rs
@@ -79,9 +79,9 @@ macro_rules! decl_settings {
                     let home = std::env::var("AGENT_HOME_NAME").expect("missing AGENT_HOME_NAME");
 
                     // Get config
-                    let config_uri = std::env::var("CONFIG_URI").ok();
-                    let config: nomad_xyz_configuration::NomadConfig = match config_uri {
-                        Some(uri) => nomad_xyz_configuration::NomadConfig::fetch(&uri).await.expect("!config uri"),
+                    let config_url = std::env::var("CONFIG_URL").ok();
+                    let config: nomad_xyz_configuration::NomadConfig = match config_url {
+                        Some(url) => nomad_xyz_configuration::NomadConfig::fetch(&url).await.expect("!config url"),
                         None => {
                             let config_path = std::env::var("CONFIG_PATH").ok();
                             match config_path {

--- a/nomad-base/src/settings/macros.rs
+++ b/nomad-base/src/settings/macros.rs
@@ -72,19 +72,25 @@ macro_rules! decl_settings {
             }
 
             impl [<$name Settings>] {
-                pub fn new() -> color_eyre::Result<Self>{
+                pub async fn new() -> color_eyre::Result<Self>{
                     // Get agent and home names
                     tracing::info!("Building settings from env");
                     let agent = std::stringify!($name).to_lowercase();
                     let home = std::env::var("AGENT_HOME_NAME").expect("missing AGENT_HOME_NAME");
 
                     // Get config
-                    let config_path = std::env::var("CONFIG_PATH").ok();
-                    let config: nomad_xyz_configuration::NomadConfig = match config_path {
-                        Some(path) => nomad_xyz_configuration::NomadConfig::from_file(path).expect("!config"),
+                    let config_uri = std::env::var("CONFIG_URI").ok();
+                    let config: nomad_xyz_configuration::NomadConfig = match config_uri {
+                        Some(uri) => nomad_xyz_configuration::NomadConfig::fetch(&uri).await.expect("!config uri"),
                         None => {
-                            let env = std::env::var("RUN_ENV").expect("missing RUN_ENV");
-                            nomad_xyz_configuration::get_builtin(&env).expect("!config").to_owned()
+                            let config_path = std::env::var("CONFIG_PATH").ok();
+                            match config_path {
+                                Some(path) => nomad_xyz_configuration::NomadConfig::from_file(path).expect("!config path"),
+                                None => {
+                                    let env = std::env::var("RUN_ENV").expect("missing RUN_ENV");
+                                    nomad_xyz_configuration::get_builtin(&env).expect("!config builtin").to_owned()
+                                }
+                            }
                         }
                     };
                     config.validate()?;

--- a/nomad-test/CHANGELOG.md
+++ b/nomad-test/CHANGELOG.md
@@ -2,4 +2,6 @@
 
 ### Unreleased
 
+- add mockito for mocking http responses
+- add helper fn for testing with an http mock
 - adds a changelog

--- a/nomad-test/CHANGELOG.md
+++ b/nomad-test/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ### Unreleased
 
+- add helper fn for testing with an http mock response
 - add mockito for mocking http responses
-- add helper fn for testing with an http mock
 - adds a changelog

--- a/nomad-test/Cargo.toml
+++ b/nomad-test/Cargo.toml
@@ -20,6 +20,7 @@ rocksdb = { git = "https://github.com/rust-rocksdb/rust-rocksdb" }
 dotenv = "0.15.0"
 tracing = "0.1.35"
 prometheus = "0.12.0"
+mockito = "0.31.0"
 
 nomad-xyz-configuration = { path = "../configuration" }
 nomad-core = { path = "../nomad-core" }

--- a/nomad-test/src/test_utils.rs
+++ b/nomad-test/src/test_utils.rs
@@ -1,4 +1,5 @@
 use futures_util::FutureExt;
+use mockito;
 use nomad_core::db::DB;
 use rand::distributions::Alphanumeric;
 use rand::{thread_rng, Rng};


### PR DESCRIPTION
## Motivation

Currently changing agent config requires updating a central config repo & rebuilding docker images. For debugging and testing, being able to override an agent's config at runtime will add speed & flexibility. 

Supports https://github.com/nomad-xyz/rust/issues/216

## Solution

Add support for a `CONFIG_URL` env var, which will take precedence over `CONFIG_PATH` and `RUN_ENV` and update config handling to support fetching a remote config.

## PR Checklist

- [x] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
