### PR TITLE
feat(relayer): add check for replica updater addresses

### DIFF
--- a/agents/relayer/CHANGELOG.md
+++ b/agents/relayer/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- relayer checks replica updater addresses match, errors channel if otherwise
 - add bootup-only tracing subscriber
 - add environment variable overrides for agent configuration
 - add tests for agent environment variable overrides

--- a/agents/relayer/src/relayer.rs
+++ b/agents/relayer/src/relayer.rs
@@ -174,7 +174,7 @@ impl NomadAgent for Relayer {
 
             ensure!(
                 home_updater == replica_updater,
-                "Home and replica updaters do not match. Home: {}. Replica: {}.",
+                "Home and replica updaters do not match. Home: {:x}. Replica: {:x}.",
                 home_updater,
                 replica_updater
             );

--- a/agents/relayer/src/relayer.rs
+++ b/agents/relayer/src/relayer.rs
@@ -1,5 +1,5 @@
 use async_trait::async_trait;
-use color_eyre::Result;
+use color_eyre::{eyre::ensure, Result};
 use std::{sync::Arc, time::Duration};
 use tokio::{sync::Mutex, task::JoinHandle, time::sleep};
 use tracing::{info, instrument::Instrumented, Instrument};
@@ -169,6 +169,16 @@ impl NomadAgent for Relayer {
     #[tracing::instrument]
     fn run(channel: Self::Channel) -> Instrumented<JoinHandle<Result<()>>> {
         tokio::spawn(async move {
+            let home_updater = channel.home().updater().await?;
+            let replica_updater = channel.replica().updater().await?;
+
+            ensure!(
+                home_updater == replica_updater,
+                "Home and replica updaters do not match. Home: {}. Replica: {}.",
+                home_updater,
+                replica_updater
+            );
+
             let update_poller = UpdatePoller::new(
                 channel.home(),
                 channel.replica(),
@@ -183,8 +193,7 @@ impl NomadAgent for Relayer {
 
 #[cfg(test)]
 mod test {
-
-    use ethers::prelude::ProviderError;
+    use ethers::prelude::{ProviderError, H256};
     use nomad_base::{
         chains::PageSettings, CommonIndexers, ContractSync, ContractSyncMetrics, CoreMetrics,
         HomeIndexers, IndexSettings, NomadDB,
@@ -233,6 +242,10 @@ mod test {
 
             {
                 home_mock.expect__name().return_const("home_1".to_owned());
+                home_mock
+                    .expect__updater()
+                    .times(..)
+                    .returning(|| Ok(H256::zero()));
             }
 
             let home = CachingHome::new(home_mock.into(), home_sync, home_db.clone()).into();
@@ -240,6 +253,10 @@ mod test {
             // Setting replica
             let mut replica_mock = MockReplicaContract::new();
             {
+                replica_mock
+                    .expect__updater()
+                    .times(..)
+                    .returning(|| Ok(H256::zero()));
                 replica_mock
                     .expect__committed_root()
                     .times(..)


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation

Only way we're noticing updater addresses are misconfigured is through `!updater sig` revert. Want to check this in relayer instead.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution

Relayer checks updater addresses match when starting a home<>replica task.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [x] Added Tests
- [ ] Updated Documentation (N/A)
- [x] Updated CHANGELOG.md for the appropriate package
