### PR TITLE
chore: update gelato sdk and resolve compilation issue

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1583,19 +1583,23 @@ dependencies = [
 [[package]]
 name = "gelato-sdk"
 version = "0.1.0-alpha"
-source = "git+https://github.com/nomad-xyz/gelato-sdk?branch=main#fb73348de7ae4628b580930d1c8068e6ce3f050d"
+source = "git+https://github.com/nomad-xyz/gelato-sdk?branch=main#d6eb8666c90928c4b68083108b052d3495584593"
 dependencies = [
  "ethers-core",
  "ethers-signers",
  "eyre",
+ "futures-timer",
+ "futures-util",
  "hex",
  "once_cell",
+ "pin-project",
  "reqwest",
  "serde 1.0.137",
  "serde_json",
  "serde_repr",
  "thiserror",
  "tracing",
+ "url",
 ]
 
 [[package]]

--- a/agents/kathy/src/settings.rs
+++ b/agents/kathy/src/settings.rs
@@ -55,7 +55,7 @@ mod test {
                     .values()
                     .map(|c| c.name.clone())
                     .collect::<HashSet<_>>();
-                settings_networks.insert(settings.base.home.name.clone());
+                settings_networks.insert(settings.base.home.name);
 
                 assert_eq!(config.networks, settings_networks);
             })

--- a/chains/nomad-ethereum/src/gelato.rs
+++ b/chains/nomad-ethereum/src/gelato.rs
@@ -134,8 +134,7 @@ where
                 let status = gelato
                     .get_task_status(task_id)
                     .await
-                    .map_err(|e| ChainCommunicationError::TxSubmissionError(e.into()))?
-                    .expect("!task status");
+                    .map_err(|e| ChainCommunicationError::TxSubmissionError(e.into()))?;
 
                 if !ACCEPTABLE_STATES.contains(&status.task_state) {
                     return Err(ChainCommunicationError::TxSubmissionError(


### PR DESCRIPTION
updates gelato-sdk to latest `main`

## Motivation

get recent enhanced logging for abnormal RPC responses

## Solution

- `cargo update -p gelato-sdk`
- delete expect on method that no longer returns an option
- driveby lint

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
- [ ] Ran PR in local/dev/staging
