### PR TITLE
fix: instrument futures, not joinhandles

### DIFF
--- a/agents/kathy/CHANGELOG.md
+++ b/agents/kathy/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- fix: instrument futures, not joinhandles
+
 ### agents@1.1.0
 
 - make \*Settings::new async for optionally fetching config from a remote url

--- a/agents/processor/CHANGELOG.md
+++ b/agents/processor/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - use `std::fmt::Display` to log contracts
+- fix: instrument futures, not joinhandles
 
 ### agents@1.1.0
 

--- a/agents/relayer/CHANGELOG.md
+++ b/agents/relayer/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - use `std::fmt::Display` to log contracts
+- fix: instrument futures, not joinhandles
 
 ### agents@1.1.0
 

--- a/agents/updater/CHANGELOG.md
+++ b/agents/updater/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- fix: instrument futures, not joinhandles
+
 ### agents@1.1.0
 
 - make \*Settings::new async for optionally fetching config from a remote url

--- a/agents/updater/src/submit.rs
+++ b/agents/updater/src/submit.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 
 use color_eyre::Result;
 use tokio::{task::JoinHandle, time::sleep};
-use tracing::{info, info_span, instrument::Instrumented, Instrument};
+use tracing::{info, info_span, Instrument};
 
 pub(crate) struct UpdateSubmitter {
     home: Arc<CachingHome>,
@@ -34,7 +34,7 @@ impl UpdateSubmitter {
         }
     }
 
-    pub(crate) fn spawn(self) -> Instrumented<JoinHandle<Result<()>>> {
+    pub(crate) fn spawn(self) -> JoinHandle<Result<()>> {
         let span = info_span!("UpdateSubmitter");
 
         tokio::spawn(async move {
@@ -79,7 +79,8 @@ impl UpdateSubmitter {
                     )
                 }
             }
-        })
+        }
         .instrument(span)
+    )
     }
 }

--- a/agents/watcher/CHANGELOG.md
+++ b/agents/watcher/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Unreleased
 
 - Add English description to XCM error log, change to use `Display`
+- fix: instrument futures, not joinhandles
 
 ### agents@1.1.0
 

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- fix: instrument futures, not joinhandles
+
 ### Unreleased
 
 - Have both Home/Replica and Home/Replica indexers return `Self::Error`

--- a/nomad-base/src/contract_sync/mod.rs
+++ b/nomad-base/src/contract_sync/mod.rs
@@ -4,8 +4,7 @@ use color_eyre::Result;
 use futures_util::future::select_all;
 use nomad_core::{CommonIndexer, HomeIndexer};
 use tokio::{task::JoinHandle, time::sleep};
-use tracing::{info, info_span};
-use tracing::{instrument::Instrumented, Instrument};
+use tracing::{info, info_span, Instrument};
 
 use std::cmp::min;
 use std::sync::Arc;
@@ -80,16 +79,16 @@ where
     I: CommonIndexer + 'static,
 {
     /// Spawn sync task to sync updates
-    pub fn spawn_common(self) -> Instrumented<JoinHandle<Result<()>>> {
+    pub fn spawn_common(self) -> JoinHandle<Result<()>> {
         let span = info_span!("ContractSync: Common", self = %self);
-        tokio::spawn(async move { self.sync_updates().await? }).instrument(span)
+        tokio::spawn(async move { self.sync_updates().await? }.instrument(span))
     }
 
     /// Spawn task that continuously looks for new on-chain updates and stores
     /// them in db. If run in timelag is off, will index at the tip
     /// but use a manual timelag to catch any missed updates. If timelag on,
     /// update  syncing will be run timelag blocks behind the tip.
-    pub fn sync_updates(&self) -> Instrumented<JoinHandle<Result<()>>> {
+    pub fn sync_updates(&self) -> JoinHandle<Result<()>> {
         let span = info_span!("UpdateContractSync");
 
         let db = self.db.clone();
@@ -118,98 +117,100 @@ where
         let config_from = self.page_settings.from;
         let chunk_size = self.page_settings.page_size;
 
-        tokio::spawn(async move {
-            let mut from = db
-                .retrieve_update_latest_block_end()
-                .map_or_else(|| config_from, |h| h);
+        tokio::spawn(
+            async move {
+                let mut from = db
+                    .retrieve_update_latest_block_end()
+                    .map_or_else(|| config_from, |h| h);
 
-            info!(from = from, "[Updates]: resuming indexer from {}", from);
+                info!(from = from, "[Updates]: resuming indexer from {}", from);
 
-            loop {
-                indexed_height.set(from as i64);
+                loop {
+                    indexed_height.set(from as i64);
 
-                let tip = indexer.get_block_number().await?;
-                if tip <= from {
-                    // Sleep if we caught up to tip
-                    sleep(Duration::from_secs(100)).await;
-                    continue;
-                }
+                    let tip = indexer.get_block_number().await?;
+                    if tip <= from {
+                        // Sleep if we caught up to tip
+                        sleep(Duration::from_secs(100)).await;
+                        continue;
+                    }
 
-                let to = min(from + chunk_size, tip);
+                    let to = min(from + chunk_size, tip);
 
-                let (start, end) = if timelag_on {
-                    // if timelag on, don't modify range
-                    (from, to)
-                } else {
-                    let range = to - from;
-                    let last_final_block = tip - finality;
-
-                    // If range includes non-final blocks, include range
-                    // blocks behind last final block
-                    let from = if to >= last_final_block {
-                        last_final_block - range
+                    let (start, end) = if timelag_on {
+                        // if timelag on, don't modify range
+                        (from, to)
                     } else {
-                        from
+                        let range = to - from;
+                        let last_final_block = tip - finality;
+
+                        // If range includes non-final blocks, include range
+                        // blocks behind last final block
+                        let from = if to >= last_final_block {
+                            last_final_block - range
+                        } else {
+                            from
+                        };
+
+                        (from, to)
                     };
 
-                    (from, to)
-                };
+                    info!(
+                        start = start,
+                        end = end,
+                        "[Updates]: indexing block heights {}...{}",
+                        start,
+                        end,
+                    );
 
-                info!(
-                    start = start,
-                    end = end,
-                    "[Updates]: indexing block heights {}...{}",
-                    start,
-                    end,
-                );
+                    let sorted_updates = indexer.fetch_sorted_updates(start, end).await?;
 
-                let sorted_updates = indexer.fetch_sorted_updates(start, end).await?;
+                    // If no updates found, update last seen block and next height
+                    // and continue
+                    if sorted_updates.is_empty() {
+                        db.store_update_latest_block_end(to)?;
+                        from = to;
+                        continue;
+                    }
 
-                // If no updates found, update last seen block and next height
-                // and continue
-                if sorted_updates.is_empty() {
-                    db.store_update_latest_block_end(to)?;
-                    from = to;
-                    continue;
-                }
+                    // Store updates
+                    db.store_updates_and_meta(&sorted_updates)?;
 
-                // Store updates
-                db.store_updates_and_meta(&sorted_updates)?;
+                    // Report latencies from emit to store if caught up
+                    if to == tip {
+                        let current_timestamp = SystemTime::now()
+                            .duration_since(UNIX_EPOCH)
+                            .expect("!timestamp")
+                            .as_secs();
+                        for update in sorted_updates.iter() {
+                            let new_root = update.signed_update.update.new_root;
 
-                // Report latencies from emit to store if caught up
-                if to == tip {
-                    let current_timestamp = SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .expect("!timestamp")
-                        .as_secs();
-                    for update in sorted_updates.iter() {
-                        let new_root = update.signed_update.update.new_root;
-
-                        if let Some(event_timestamp) = update.metadata.timestamp {
-                            let latency = current_timestamp - event_timestamp;
-                            info!(
-                                new_root = ?new_root,
-                                latency = latency,
-                                "Latency for update with new_root {}: {}.",
-                                new_root,
-                                latency,
-                            );
-                            store_update_latency.observe(latency as f64);
-                        } else {
-                            info!("No timestamp for update with new_root: {}.", new_root);
+                            if let Some(event_timestamp) = update.metadata.timestamp {
+                                let latency = current_timestamp - event_timestamp;
+                                info!(
+                                    new_root = ?new_root,
+                                    latency = latency,
+                                    "Latency for update with new_root {}: {}.",
+                                    new_root,
+                                    latency,
+                                );
+                                store_update_latency.observe(latency as f64);
+                            } else {
+                                info!("No timestamp for update with new_root: {}.", new_root);
+                            }
                         }
                     }
+
+                    // Report amount of updates stored into db
+                    stored_updates.add(sorted_updates.len().try_into()?);
+
+                    // Move forward next height
+                    db.store_update_latest_block_end(to)?;
+                    from = to;
                 }
-
-                // Report amount of updates stored into db
-                stored_updates.add(sorted_updates.len().try_into()?);
-
-                // Move forward next height
-                db.store_update_latest_block_end(to)?;
-                from = to;
             }
-        })
-        .instrument(span)
+            .instrument(span),
+        )
     }
 }
 
@@ -218,26 +219,28 @@ where
     I: HomeIndexer + 'static,
 {
     /// Spawn sync task to sync home updates (and potentially messages)
-    pub fn spawn_home(self) -> Instrumented<JoinHandle<Result<()>>> {
+    pub fn spawn_home(self) -> JoinHandle<Result<()>> {
         let span = info_span!("ContractSync: Home", self = %self);
         let data_types = self.index_settings.data_types();
 
-        tokio::spawn(async move {
-            let tasks = match data_types {
-                IndexDataTypes::Updates => vec![self.sync_updates()],
-                IndexDataTypes::UpdatesAndMessages => {
-                    vec![self.sync_updates(), self.sync_messages()]
+        tokio::spawn(
+            async move {
+                let tasks = match data_types {
+                    IndexDataTypes::Updates => vec![self.sync_updates()],
+                    IndexDataTypes::UpdatesAndMessages => {
+                        vec![self.sync_updates(), self.sync_messages()]
+                    }
+                };
+
+                let (_, _, remaining) = select_all(tasks).await;
+                for task in remaining.into_iter() {
+                    cancel_task!(task);
                 }
-            };
 
-            let (_, _, remaining) = select_all(tasks).await;
-            for task in remaining.into_iter() {
-                cancel_task!(task);
+                Ok(())
             }
-
-            Ok(())
-        })
-        .instrument(span)
+            .instrument(span),
+        )
     }
 
     /// Spawn task that continuously looks for new on-chain messages and stores
@@ -245,7 +248,7 @@ where
     /// ordering of messages is not guaranteed like it is for updates. Running
     /// without a timelag could cause messages with the incorrectly ordered
     /// index to be stored.
-    pub fn sync_messages(&self) -> Instrumented<JoinHandle<Result<()>>> {
+    pub fn sync_messages(&self) -> JoinHandle<Result<()>> {
         let span = info_span!("MessageContractSync");
 
         let db = self.db.clone();
@@ -268,63 +271,65 @@ where
         let config_from = self.page_settings.from;
         let chunk_size = self.page_settings.page_size;
 
-        tokio::spawn(async move {
-            let mut from = db
-                .retrieve_message_latest_block_end()
-                .map_or_else(|| config_from, |h| h);
+        tokio::spawn(
+            async move {
+                let mut from = db
+                    .retrieve_message_latest_block_end()
+                    .map_or_else(|| config_from, |h| h);
 
-            info!(from = from, "[Messages]: resuming indexer from {}", from);
+                info!(from = from, "[Messages]: resuming indexer from {}", from);
 
-            loop {
-                indexed_height.set(from as i64);
+                loop {
+                    indexed_height.set(from as i64);
 
-                let tip = indexer.get_block_number().await?;
-                if tip <= from {
-                    // Sleep if caught up to tip
-                    sleep(Duration::from_secs(100)).await;
-                    continue;
-                }
+                    let tip = indexer.get_block_number().await?;
+                    if tip <= from {
+                        // Sleep if caught up to tip
+                        sleep(Duration::from_secs(100)).await;
+                        continue;
+                    }
 
-                let candidate = from + chunk_size;
-                let to = min(tip, candidate);
+                    let candidate = from + chunk_size;
+                    let to = min(tip, candidate);
 
-                // timelag always applied
-                let (start, end) = if timelag_on {
-                    (from, to)
-                } else {
-                    panic!("Syncing messages with timelag off should never happen!");
-                };
+                    // timelag always applied
+                    let (start, end) = if timelag_on {
+                        (from, to)
+                    } else {
+                        panic!("Syncing messages with timelag off should never happen!");
+                    };
 
-                info!(
-                    start = start,
-                    end = end,
-                    "[Messages]: indexing block heights {}...{}",
-                    start,
-                    end
-                );
+                    info!(
+                        start = start,
+                        end = end,
+                        "[Messages]: indexing block heights {}...{}",
+                        start,
+                        end
+                    );
 
-                let sorted_messages = indexer.fetch_sorted_messages(start, end).await?;
+                    let sorted_messages = indexer.fetch_sorted_messages(start, end).await?;
 
-                // If no messages found, update last seen block and next height
-                // and continue
-                if sorted_messages.is_empty() {
+                    // If no messages found, update last seen block and next height
+                    // and continue
+                    if sorted_messages.is_empty() {
+                        db.store_message_latest_block_end(to)?;
+                        from = to;
+                        continue;
+                    }
+
+                    // Store messages
+                    db.store_messages(&sorted_messages)?;
+
+                    // Report amount of messages stored into db
+                    stored_messages.add(sorted_messages.len().try_into()?);
+
+                    // Move forward next height
                     db.store_message_latest_block_end(to)?;
                     from = to;
-                    continue;
                 }
-
-                // Store messages
-                db.store_messages(&sorted_messages)?;
-
-                // Report amount of messages stored into db
-                stored_messages.add(sorted_messages.len().try_into()?);
-
-                // Move forward next height
-                db.store_message_latest_block_end(to)?;
-                from = to;
             }
-        })
-        .instrument(span)
+            .instrument(span),
+        )
     }
 }
 

--- a/nomad-base/src/home.rs
+++ b/nomad-base/src/home.rs
@@ -11,7 +11,7 @@ use nomad_test::mocks::MockHomeContract;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
-use tracing::{instrument, instrument::Instrumented};
+use tracing::instrument;
 
 /// Caching replica type
 #[derive(Debug)]
@@ -49,7 +49,7 @@ impl CachingHome {
 
     /// Spawn a task that syncs the CachingHome's db with the on-chain event
     /// data
-    pub fn sync(&self) -> Instrumented<JoinHandle<Result<()>>> {
+    pub fn sync(&self) -> JoinHandle<Result<()>> {
         let sync = self.contract_sync.clone();
         sync.spawn_home()
     }

--- a/nomad-base/src/macros.rs
+++ b/nomad-base/src/macros.rs
@@ -4,9 +4,8 @@ macro_rules! cancel_task {
     ($task:ident) => {
         #[allow(unused_must_use)]
         {
-            let t = $task.into_inner();
-            t.abort();
-            t.await;
+            $task.abort();
+            $task.await;
         }
     };
 }

--- a/nomad-base/src/replica.rs
+++ b/nomad-base/src/replica.rs
@@ -5,6 +5,7 @@ use nomad_core::{
     accumulator::NomadProof, db::DbError, Common, CommonEvents, DoubleUpdate, MessageStatus,
     NomadMessage, Replica, SignedUpdate, State, TxOutcome,
 };
+use tracing::instrument;
 
 use crate::{ChainCommunicationError, NomadDB};
 
@@ -13,7 +14,6 @@ use nomad_test::mocks::MockReplicaContract;
 use std::sync::Arc;
 use tokio::task::JoinHandle;
 use tokio::time::{sleep, Duration};
-use tracing::{instrument, instrument::Instrumented};
 
 use crate::{CommonIndexers, ContractSync};
 
@@ -57,7 +57,7 @@ impl CachingReplica {
 
     /// Spawn a task that syncs the CachingReplica's db with the on-chain event
     /// data
-    pub fn sync(&self) -> Instrumented<JoinHandle<Result<()>>> {
+    pub fn sync(&self) -> JoinHandle<Result<()>> {
         let sync = self.contract_sync.clone();
         sync.spawn_common()
     }


### PR DESCRIPTION
## Motivation

A misunderstanding of the tracing/futures interaction caused many span we were creating to be improperly suppressed

## Solution

Apply the spans to the futures, not the join handles wrapping tasks containing those futures

@yourbuddyconner @arnaud036 this will enable many spans that were previously accidentally suppressed, causing log output to be more significantly more detailed and verbose. It may require some tuning if it's toooo verbose

@luketchang @lattejed dear reviewers, this PR is not as big as it seems. the move from `}).instrument()` to `}.instrument())` caused an extra indentation for affected blocks, and in some cases re-formatting on the rustfmt run. The changes are closer to 30 lines than 300 😅 

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
- [] Ran PR in local/dev/staging
