### PR TITLE
Lattejed/chain centric watcher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5030,36 +5030,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "watcher"
-version = "1.0.0"
-dependencies = [
- "affix",
- "async-trait",
- "color-eyre",
- "config 0.10.1",
- "dotenv",
- "ethers",
- "futures-util",
- "log",
- "nomad-base",
- "nomad-core",
- "nomad-ethereum",
- "nomad-test",
- "nomad-xyz-configuration",
- "prometheus",
- "rocksdb",
- "serde 1.0.137",
- "serde_json",
- "serial_test",
- "thiserror",
- "tokio",
- "tokio-test",
- "tracing",
- "tracing-futures",
- "tracing-subscriber 0.3.14",
-]
-
-[[package]]
 name = "web-sys"
 version = "0.3.57"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ members = [
     "agents/kathy",
     "agents/updater",
     "agents/relayer",
-    "agents/watcher",
+#    "agents/watcher",
     "agents/processor",
     "tools/kms-cli",
     "tools/nomad-cli",

--- a/agents/kathy/src/kathy.rs
+++ b/agents/kathy/src/kathy.rs
@@ -67,12 +67,13 @@ impl NomadAgent for Kathy {
     }
 
     fn build_channel(&self, replica: &str) -> Self::Channel {
+        let home = self.connections().home().expect("!home");
         Self::Channel {
             base: self.channel_base(replica),
             home_lock: self.home_lock.clone(),
             generator: self.generator.clone(),
             messages_dispatched: self.messages_dispatched.with_label_values(&[
-                self.home().name(),
+                home.name(),
                 replica,
                 Self::AGENT_NAME,
             ]),

--- a/agents/relayer/src/relayer.rs
+++ b/agents/relayer/src/relayer.rs
@@ -155,10 +155,11 @@ impl NomadAgent for Relayer {
     }
 
     fn build_channel(&self, replica: &str) -> Self::Channel {
+        let home = self.connections().home().expect("!home");
         Self::Channel {
             base: self.channel_base(replica),
             updates_relayed_count: self.updates_relayed_counts.with_label_values(&[
-                self.home().name(),
+                home.name(),
                 replica,
                 Self::AGENT_NAME,
             ]),

--- a/agents/relayer/src/relayer.rs
+++ b/agents/relayer/src/relayer.rs
@@ -196,8 +196,8 @@ impl NomadAgent for Relayer {
 mod test {
     use ethers::prelude::{ProviderError, H256};
     use nomad_base::{
-        chains::PageSettings, CommonIndexers, ContractSync, ContractSyncMetrics, CoreMetrics,
-        HomeIndexers, IndexSettings, NomadDB,
+        chains::PageSettings, AgentConnections, CommonIndexers, ContractSync, ContractSyncMetrics,
+        CoreMetrics, HomeIndexers, IndexSettings, NomadDB,
     };
     use nomad_core::ChainCommunicationError;
     use nomad_test::mocks::{MockHomeContract, MockIndexer, MockReplicaContract};
@@ -294,8 +294,7 @@ mod test {
 
             // Setting agent
             let core = AgentCore {
-                home,
-                replicas,
+                connections: AgentConnections::Default { home, replicas },
                 db,
                 metrics,
                 indexer: IndexSettings::default(),

--- a/nomad-base/src/agent.rs
+++ b/nomad-base/src/agent.rs
@@ -25,13 +25,29 @@ use tokio::{task::JoinHandle, time::sleep};
 
 const MAX_EXPONENTIAL: u32 = 7; // 2^7 = 128 second timeout
 
+/// General or agent-specific connection map
+#[derive(Debug, Clone)]
+pub enum AgentConnections {
+    /// Connections for watchers
+    Watcher {
+        /// A map of boxed Homes
+        homes: HashMap<String, Arc<CachingHome>>,
+        // ...
+    },
+    /// Connections for other agents
+    Default {
+        /// A boxed Home
+        home: Arc<CachingHome>,
+        /// A map of boxed Replicas
+        replicas: HashMap<String, Arc<CachingReplica>>,
+    },
+}
+
 /// Properties shared across all agents
 #[derive(Debug, Clone)]
 pub struct AgentCore {
-    /// A boxed Home
-    pub home: Arc<CachingHome>,
-    /// A map of boxed Replicas
-    pub replicas: HashMap<String, Arc<CachingReplica>>,
+    /// Agent connections
+    pub connections: AgentConnections,
     /// A persistent KV Store (currently implemented as rocksdb)
     pub db: DB,
     /// Prometheus metrics

--- a/nomad-base/src/agent.rs
+++ b/nomad-base/src/agent.rs
@@ -43,6 +43,32 @@ pub enum AgentConnections {
     },
 }
 
+/// Accessor methods for AgentConnections
+impl AgentConnections {
+    /// Get an optional clone of home
+    pub fn home(&self) -> Option<Arc<CachingHome>> {
+        use AgentConnections::*;
+        match self {
+            Default { home, .. } => Some(home.clone()),
+            _ => None,
+        }
+    }
+
+    /// Get an optional clone of the map of replicas
+    pub fn replicas(&self) -> Option<HashMap<String, Arc<CachingReplica>>> {
+        use AgentConnections::*;
+        match self {
+            Default { replicas, .. } => Some(replicas.clone()),
+            _ => None,
+        }
+    }
+
+    /// Get an optional clone of a replica by its name
+    pub fn replica_by_name(&self, name: &str) -> Option<Arc<CachingReplica>> {
+        self.replicas().and_then(|r| r.get(name).map(Clone::clone))
+    }
+}
+
 /// Properties shared across all agents
 #[derive(Debug, Clone)]
 pub struct AgentCore {
@@ -111,19 +137,9 @@ pub trait NomadAgent: Send + Sync + Sized + std::fmt::Debug + AsRef<AgentCore> {
         self.as_ref().db.clone()
     }
 
-    /// Return a reference to a home contract
-    fn home(&self) -> Arc<CachingHome> {
-        self.as_ref().home.clone()
-    }
-
-    /// Get a reference to the replicas map
-    fn replicas(&self) -> &HashMap<String, Arc<CachingReplica>> {
-        &self.as_ref().replicas
-    }
-
-    /// Get a reference to a replica by its name
-    fn replica_by_name(&self, name: &str) -> Option<Arc<CachingReplica>> {
-        self.replicas().get(name).map(Clone::clone)
+    /// Return a reference to the connections object
+    fn connections(&self) -> &AgentConnections {
+        &self.as_ref().connections
     }
 
     /// Run the agent with the given home and replica

--- a/nomad-base/src/settings/mod.rs
+++ b/nomad-base/src/settings/mod.rs
@@ -11,8 +11,9 @@
 //! corresponding env file and/or secrets.json file.
 
 use crate::{
-    agent::AgentCore, CachingHome, CachingReplica, CommonIndexerVariants, CommonIndexers,
-    ContractSync, ContractSyncMetrics, HomeIndexerVariants, HomeIndexers, Homes, NomadDB, Replicas,
+    agent::AgentCore, AgentConnections, CachingHome, CachingReplica, CommonIndexerVariants,
+    CommonIndexers, ContractSync, ContractSyncMetrics, HomeIndexerVariants, HomeIndexers, Homes,
+    NomadDB, Replicas,
 };
 use color_eyre::{eyre::bail, Result};
 use nomad_core::{db::DB, Common, ContractLocator};
@@ -419,8 +420,7 @@ impl Settings {
             .await?;
 
         Ok(AgentCore {
-            home,
-            replicas,
+            connections: AgentConnections::Default { home, replicas },
             db,
             settings: self.clone(),
             metrics,


### PR DESCRIPTION
## Motivation

An operator running a watcher is typically an app owner or L1 partner (chain-centric). In the current, home-centric agent design, they must currently run N watcher instances for each home<>replica channel leading to the chain of interest (high operational burden). A chain-centric watcher would lower that operational burden as well as simplify watcher funding.

## Solution

Refactor watcher to watch over all incoming connections to a chain.

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
- [ ] Ran PR in local/dev/staging
