### PR TITLE
fix: prevent some gigantic log lines by adding better display impls

### DIFF
--- a/agents/processor/CHANGELOG.md
+++ b/agents/processor/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- use display to log contracts
+- use `std::fmt::Display` to log contracts
 
 ### agents@1.1.0
 

--- a/agents/processor/CHANGELOG.md
+++ b/agents/processor/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- use display to log contracts
+
 ### agents@1.1.0
 
 - make \*Settings::new async for optionally fetching config from a remote url

--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -49,7 +49,7 @@ impl std::fmt::Display for Replica {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "ReplicaProcessor: {{ home: {:?}, replica: {:?}, allowed: {:?}, denied: {:?} }}",
+            "ReplicaProcessor: {{ home: {}, replica: {}, allowed: {:?}, denied: {:?} }}",
             self.home, self.replica, self.allowed, self.denied
         )
     }

--- a/agents/relayer/CHANGELOG.md
+++ b/agents/relayer/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- use display to log contracts
+- use `std::fmt::Display` to log contracts
 
 ### agents@1.1.0
 

--- a/agents/relayer/CHANGELOG.md
+++ b/agents/relayer/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- use display to log contracts
+
 ### agents@1.1.0
 
 - make \*Settings::new async for optionally fetching config from a remote url

--- a/agents/relayer/src/relayer.rs
+++ b/agents/relayer/src/relayer.rs
@@ -22,7 +22,7 @@ impl std::fmt::Display for UpdatePoller {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "UpdatePoller: {{ home: {:?}, replica: {:?} }}",
+            "UpdatePoller: {{ home: {}, replica: {} }}",
             self.home, self.replica
         )
     }

--- a/agents/watcher/CHANGELOG.md
+++ b/agents/watcher/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ### Unreleased
 
+- Add English description to XCM error log, change to use `Display`
+
 ### agents@1.1.0
 
 - make \*Settings::new async for optionally fetching config from a remote url

--- a/agents/watcher/src/watcher.rs
+++ b/agents/watcher/src/watcher.rs
@@ -548,7 +548,7 @@ impl NomadAgent for Watcher {
         // Report any invalid ConnectionManager chain setups
         errors.into_iter().for_each(|e| {
             let err = e.unwrap_err();
-            tracing::error!("{:?}", err)
+            tracing::error!(err = %err, "Invalid XCM setup");
         });
 
         let connection_managers: Vec<_> = connection_managers

--- a/chains/nomad-ethereum/CHANGELOG.md
+++ b/chains/nomad-ethereum/CHANGELOG.md
@@ -2,6 +2,6 @@
 
 ### Unreleased
 
-- impl display for Home and Replica
+- impl `std::fmt::Display` for `EthereumHome` and `EthereumReplica`
 - use gelato-sdk as a github dep rather than a crate
 - adds a changelog

--- a/chains/nomad-ethereum/CHANGELOG.md
+++ b/chains/nomad-ethereum/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ### Unreleased
 
+- impl display for Home and Replica
 - use gelato-sdk as a github dep rather than a crate
 - adds a changelog

--- a/chains/nomad-ethereum/src/home.rs
+++ b/chains/nomad-ethereum/src/home.rs
@@ -210,6 +210,22 @@ where
     }
 }
 
+impl<W, R> std::fmt::Display for EthereumHome<W, R>
+where
+    W: ethers::providers::Middleware + 'static,
+    R: ethers::providers::Middleware + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "EthereumHome {{ address: {}, domain: {}, name: {} }}",
+            self.contract.address(),
+            self.domain,
+            self.name,
+        )
+    }
+}
+
 #[async_trait]
 impl<W, R> Common for EthereumHome<W, R>
 where

--- a/chains/nomad-ethereum/src/replica.rs
+++ b/chains/nomad-ethereum/src/replica.rs
@@ -169,6 +169,22 @@ where
     }
 }
 
+impl<W, R> std::fmt::Display for EthereumReplica<W, R>
+where
+    W: ethers::providers::Middleware + 'static,
+    R: ethers::providers::Middleware + 'static,
+{
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "EthereumHome {{ address: {}, domain: {}, name: {} }}",
+            self.contract.address(),
+            self.domain,
+            self.name
+        )
+    }
+}
+
 #[async_trait]
 impl<W, R> Common for EthereumReplica<W, R>
 where

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- implement display for home and replica enums
 - add home and remote labels to contract sync metrics for event differentiation
 - add `CONFIG_URL` check to `decl_settings` to optionally fetch config from a remote url
 - prometheus metrics accepts port by env var

--- a/nomad-base/CHANGELOG.md
+++ b/nomad-base/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ### Unreleased
 
-- implement display for home and replica enums
+- implement `std::fmt::Display` for `Home` and `Replica` enums
 - add home and remote labels to contract sync metrics for event differentiation
 - add `CONFIG_URL` check to `decl_settings` to optionally fetch config from a remote url
 - prometheus metrics accepts port by env var

--- a/nomad-base/src/home.rs
+++ b/nomad-base/src/home.rs
@@ -23,7 +23,7 @@ pub struct CachingHome {
 
 impl std::fmt::Display for CachingHome {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self)
+        write!(f, "CachingHome {}", self.home)
     }
 }
 
@@ -199,6 +199,12 @@ impl CommonEvents for CachingHome {
 /// Arc wrapper for HomeVariants enum
 pub struct Homes(Arc<HomeVariants>);
 
+impl std::fmt::Display for Homes {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
 impl From<HomeVariants> for Homes {
     fn from(homes: HomeVariants) -> Self {
         Self(Arc::new(homes))
@@ -228,6 +234,23 @@ pub enum HomeVariants {
     Mock(Box<MockHomeContract>),
     /// Other home variant
     Other(Box<dyn Home>),
+}
+
+impl std::fmt::Display for HomeVariants {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HomeVariants::Ethereum(inner) => {
+                write!(
+                    f,
+                    "{{ Home for {} {} }}",
+                    inner.local_domain(),
+                    inner.name()
+                )
+            }
+            HomeVariants::Mock(_inner) => write!(f, "MockHome"),
+            HomeVariants::Other(_inner) => write!(f, "OtherHome"),
+        }
+    }
 }
 
 impl HomeVariants {

--- a/nomad-base/src/replica.rs
+++ b/nomad-base/src/replica.rs
@@ -188,6 +188,18 @@ pub enum ReplicaVariants {
     Other(Box<dyn Replica>),
 }
 
+impl std::fmt::Display for ReplicaVariants {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ReplicaVariants::Ethereum(inner) => {
+                write!(f, "{}", inner)
+            }
+            ReplicaVariants::Mock(inner) => write!(f, "{}", inner),
+            ReplicaVariants::Other(inner) => write!(f, "{}", inner),
+        }
+    }
+}
+
 impl ReplicaVariants {
     /// Calls checkpoint on mock variant. Should
     /// only be used during tests.

--- a/nomad-core/CHANGELOG.md
+++ b/nomad-core/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- require `Common: std::fmt::Display`
 - refactor: Add IRSA credentials to client instantiation
 - implement `Encode` and `Decode` for `bool`
 - adds a changelog

--- a/nomad-core/src/traits/mod.rs
+++ b/nomad-core/src/traits/mod.rs
@@ -108,7 +108,7 @@ where
 
 /// Interface for attributes shared by Home and Replica
 #[async_trait]
-pub trait Common: Sync + Send + std::fmt::Debug {
+pub trait Common: Sync + Send + std::fmt::Debug + std::fmt::Display {
     /// Return an identifier (not necessarily unique) for the chain this
     /// contract is running on.
     fn name(&self) -> &str;

--- a/nomad-test/CHANGELOG.md
+++ b/nomad-test/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- implement `Display` for mock contracts
 - add helper fn for testing with an http mock response
 - add mockito for mocking http responses
 - adds a changelog

--- a/nomad-test/src/mocks/home.rs
+++ b/nomad-test/src/mocks/home.rs
@@ -72,6 +72,12 @@ impl std::fmt::Debug for MockHomeContract {
     }
 }
 
+impl std::fmt::Display for MockHomeContract {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MockHome")
+    }
+}
+
 #[async_trait]
 impl Home for MockHomeContract {
     fn local_domain(&self) -> u32 {

--- a/nomad-test/src/mocks/replica.rs
+++ b/nomad-test/src/mocks/replica.rs
@@ -53,6 +53,12 @@ impl std::fmt::Debug for MockReplicaContract {
     }
 }
 
+impl std::fmt::Display for MockReplicaContract {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "MockReplica")
+    }
+}
+
 #[async_trait]
 impl Replica for MockReplicaContract {
     fn local_domain(&self) -> u32 {


### PR DESCRIPTION


## Motivation

Because the contracts don't implement display, we used debug for them. This was a bad idea

## Solution

- require `Common` inheritors to implement `Display`
- use `Display` when emitting events

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
- [ ] Ran PR in local/dev/staging
