### PR TITLE
Prestwich/double update sig check

### DIFF
--- a/agents/processor/src/processor.rs
+++ b/agents/processor/src/processor.rs
@@ -225,7 +225,7 @@ impl Replica {
         Ok(Flow::Advance)
     }
 
-    #[instrument(err, level = "info", skip(self), fields(self = %self, domain = message.message.destination, nonce = message.message.nonce, leaf_index = message.leaf_index, leaf = ?message.message.to_leaf()))]
+    #[instrument(err, level = "info", skip(self, message), fields(self = %self, domain = message.message.destination, nonce = message.message.nonce, leaf_index = message.leaf_index, leaf = ?message.message.to_leaf()))]
     /// Dispatch a message for processing. If the message is already proven, process only.
     async fn process(&self, message: CommittedMessage, proof: NomadProof) -> Result<()> {
         use nomad_core::Replica;

--- a/agents/watcher/CHANGELOG.md
+++ b/agents/watcher/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+- update handler now errors if incoming updates have an unexpected updater
+- double-update routine now checks that both updates are signed by the same
+  updater
 - Add English description to XCM error log, change to use `Display`
 
 ### agents@1.1.0

--- a/agents/watcher/src/watcher.rs
+++ b/agents/watcher/src/watcher.rs
@@ -299,7 +299,7 @@ impl UpdateHandler {
                 // this is
                 ensure!(
                     update.verify(self.updater).is_ok(),
-                    "Handling update signed by another updater. This agent is misconfigured"
+                    "Handling update signed by another updater. Hint: This agent may misconfigured, or the updater may have rotated while this agent was running"
                 );
 
                 if old_root == self.home.committed_root().await? {

--- a/nomad-core/src/types/update.rs
+++ b/nomad-core/src/types/update.rs
@@ -25,7 +25,7 @@ impl std::fmt::Display for Update {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(
             f,
-            "Update(domain {} moved from {} to {})",
+            "Update(domain {} moved from {:?} to {:?})",
             self.home_domain, self.previous_root, self.new_root
         )
     }


### PR DESCRIPTION


## Motivation

Prevent false positive double-updates
Prevent watcher from using an old configuration after an updater rotation

## Solution

Prevent false positives on double updates by checking that the 2 updates match eachothers' signatures.
Check on each inbound update that the signer matches the configured updater


## PR Checklist

- [ ] Added Tests
- [x] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
- [ ] Ran PR in local/dev/staging
