### PR TITLE
Bump `configuration` version to 1.0.0 after adding substrate to config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2637,7 +2637,7 @@ dependencies = [
 
 [[package]]
 name = "nomad-xyz-configuration"
-version = "0.1.0"
+version = "1.0.0-rc.1"
 dependencies = [
  "affix",
  "dotenv",

--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,8 +2,10 @@
 
 ### Unreleased
 
+### v1.0.0-rc.1
+
 - feature: add additional config called `configs/testMultiVm.json` which has outbound connections to other chains but no inbound connections (no substrate replica support)
-- refactor: change contract info (previously CoreContracts and BridgeContracts) to be CoreDeploymentInfo and BridgeDeploymentInfo, with support for substrate variant
+- refactor: change contract info (previously CoreContracts and BridgeContracts) to be CoreDeploymentInfo and BridgeDeploymentInfo, with support for substrate variant (not backwards compatible given core and bridge deploy/contract info is now a union not a struct)
 - feature: update TS definitions for wasm_bindgen with Substrate-related changes
 - feature: add more explicit Processor Config TS declaration
 - refactor: make Processor config keys optional, and prevent trivial ser.

--- a/configuration/Cargo.toml
+++ b/configuration/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomad-xyz-configuration"
-version = "0.1.0"
+version = "1.0.0-rc.1"
 edition = "2021"
 authors = ["James Prestwich <james@nomad.xyz>", "The Nomad Developers <eng@nomad.xyz>"]
 description = "Nomad project configuration file utilities"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
Substrate compatible agents and deploy script.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
#233 integrated substrate into `configuration` crate, this PR prepares new RC.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests (N/A)
- [ ] Updated Documentation (N/A)
- [x] Updated CHANGELOG.md for the appropriate package
- [ ] Ran PR in local/dev/staging (N/A)
