### PR TITLE
Added substrate network

### DIFF
--- a/configuration/src/network.rs
+++ b/configuration/src/network.rs
@@ -85,12 +85,36 @@ pub struct Domain {
     pub domain: u32,
     /// List of connections to other networks
     pub connections: HashSet<String>,
+    /// Nomad and network specific information depending on network type
+    pub network_specs: NetworkType,
+}
+
+/// Evm network based configuration
+#[derive(Default, Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct EvmNetworkSpecs {
     /// Nomad protocol configuration options
     pub configuration: ContractConfig,
     /// Network specifications
     pub specs: NetworkSpecs,
     /// Bridge contract configuration options
     pub bridge_configuration: BridgeConfiguration,
+}
+
+/// Nomad and network specific information depending on network type
+#[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
+#[serde(rename_all = "camelCase", tag = "type")]
+pub enum NetworkType {
+    /// EVM Core
+    Ethereum(EvmNetworkSpecs),
+    /// Substrate core
+    Substrate,
+}
+
+impl Default for NetworkType {
+    fn default() -> Self {
+        NetworkType::Ethereum(EvmNetworkSpecs::default())
+    }
 }
 
 /// Core deployment info


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below. Bug fixes and new features should include tests.

New contributors should read the contributors guide:
https://github.com/nomad-xyz/monorepo/blob/master/CONTRIBUTING.md

The contributors guide includes instructions for running rustfmt and building
the documentation.
-->

## Motivation
We want a clear distinction between EVM and others networks (ie Substrate).
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? In some cases there is not a problem and this can be
thought of as being the motivation for your change.
-->

## Solution
Added an enum into domain, which specifies whether the network is EVM (with info inside) or Substrate (empty)
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [ ] Updated CHANGELOG.md for the appropriate package
- [ ] Ran PR in local/dev/staging
