### PR TITLE
fix(configuration): prevent SignerConf from being logged with secrets

### DIFF
--- a/configuration/CHANGELOG.md
+++ b/configuration/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ### Unreleased
 
+- fix: SignerConf should not Display or Debug secrets
+- add tests for SignerConf to ensure it does not Display or Debug secrets
+
 ### v1.0.0-rc.1
 
 - feature: add additional config called `configs/testMultiVm.json` which has outbound connections to other chains but no inbound connections (no substrate replica support)


### PR DESCRIPTION
## Motivation

Recent changes to Watcher to make it more verbose in logging incorrectly included the secrets contained in `SignerConf`

## Solution

Rather than remove the offending logging from Watcher, prevent `SignerConf` from printing `Debug` or `Display` that includes secrets to ensure this mistake is not repeated in the future

## PR Checklist

- [x] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
- [ ] Ran PR in local/dev/staging
