### PR TITLE
fix: double-update is now a nop in avail

### DIFF
--- a/chains/nomad-substrate/CHANGELOG.md
+++ b/chains/nomad-substrate/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ### Unreleased
 
+- Change `double_update` to a NOP
 - Update `update` method with new max index field
 - `produce_update` checks that tree has at least 1 element (bug fix)
 - Add timelag functionality to `NomadOnlineClient` which wraps storage fetches with timelagged fetches

--- a/chains/nomad-substrate/src/home.rs
+++ b/chains/nomad-substrate/src/home.rs
@@ -267,7 +267,9 @@ where
 
     #[tracing::instrument(err, skip(self))]
     async fn double_update(&self, _double: &DoubleUpdate) -> Result<TxOutcome, Self::Error> {
-        unimplemented!("Double update deprecated for Substrate implementations")
+        Ok(TxOutcome {
+            txid: Default::default(),
+        })
     }
 }
 


### PR DESCRIPTION

## Motivation

Resolve panic issue in avail testing

## Solution

Remove `unimplemented!` and replace with a nop outcome

## PR Checklist

- [ ] Added Tests
- [ ] Updated Documentation
- [x] Updated CHANGELOG.md for the appropriate package
- [ ] Ran PR in local/dev/staging
